### PR TITLE
Implement `clearCacheForPage` on iOS

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pspdfkit-cordova",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "PSPDFKit Cordova Plugin for Android and iOS",
   "cordova": {
     "id": "pspdfkit-cordova",

--- a/plugin.xml
+++ b/plugin.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<plugin xmlns="http://apache.org/cordova/ns/plugins/1.0" xmlns:android="http://schemas.android.com/apk/res/android" id="pspdfkit-cordova" version="1.0.1">
+<plugin xmlns="http://apache.org/cordova/ns/plugins/1.0" xmlns:android="http://schemas.android.com/apk/res/android" id="pspdfkit-cordova" version="1.0.2">
   <engines>
     <engine name="cordova" version="&gt;=6.3.1" />
   </engines>

--- a/src/ios/PSPDFKitPlugin.m
+++ b/src/ios/PSPDFKitPlugin.m
@@ -1296,12 +1296,7 @@ void runOnMainQueueWithoutDeadlocking(void (^block)(void)) {
 
 - (void)clearCacheForPage:(CDVInvokedUrlCommand *)command {
     PSPDFPageIndex pageIndex = (PSPDFPageIndex)[[command argumentAtIndex:0] longLongValue];
-    PSPDFDocument *document = self.pdfController.document;
-    VALIDATE_DOCUMENT(document);
-
-    [PSPDFKitGlobal.sharedInstance.cache invalidateImageFromDocument:document pageIndex:pageIndex];
     [self.pdfController reloadPageAtIndex:pageIndex animated:NO];
-
     [self.commandDelegate sendPluginResult:[CDVPluginResult resultWithStatus:CDVCommandStatus_OK] callbackId:command.callbackId];
 }
 

--- a/src/ios/PSPDFKitPlugin.m
+++ b/src/ios/PSPDFKitPlugin.m
@@ -1294,6 +1294,17 @@ void runOnMainQueueWithoutDeadlocking(void (^block)(void)) {
     [self.commandDelegate sendPluginResult:[CDVPluginResult resultWithStatus:CDVCommandStatus_OK] callbackId:command.callbackId];
 }
 
+- (void)clearCacheForPage:(CDVInvokedUrlCommand *)command {
+    PSPDFPageIndex pageIndex = (PSPDFPageIndex)[[command argumentAtIndex:0] longLongValue];
+    PSPDFDocument *document = self.pdfController.document;
+    VALIDATE_DOCUMENT(document);
+
+    [PSPDFKitGlobal.sharedInstance.cache invalidateImageFromDocument:document pageIndex:pageIndex];
+    [self.pdfController reloadPageAtIndex:pageIndex animated:NO];
+
+    [self.commandDelegate sendPluginResult:[CDVPluginResult resultWithStatus:CDVCommandStatus_OK] callbackId:command.callbackId];
+}
+
 #pragma mark Paging
 
 - (void)setPage:(CDVInvokedUrlCommand *)command {

--- a/www/PSPDFKit.js
+++ b/www/PSPDFKit.js
@@ -581,10 +581,11 @@ exports.removeCacheForPresentedDocument = function(callback) {
  *
  * __Supported Platforms__
  *
+ * -iOS
  * -Android
  */
 exports.clearCacheForPage = function(pageIndex, callback) {
-  if (platform === "android") {
+  if (platform === "ios" || platform === "android") {
     executeAction(callback, "clearCacheForPage", [pageIndex]);
   } else {
     console.log("Not implemented on " + platform + ".");


### PR DESCRIPTION
# Details

This PR implements `clearCacheForPage` for iOS. On Android, we implemented it in #5.

### JavaScript Usage:

```js
PSPDFKit.clearCacheForPage(0, function() {
  alert("Cache cleared.");
});
```

# Acceptance Criteria

- [x] When approved, right before merging, rebase with master and increment the package version in `package.json` and `plugin.xml`(see example commit: https://github.com/PSPDFKit/PSPDFKit-Cordova/commit/09d5c6b1c12977dc2248c02d869c3247ff5ed6f5).
- [x] Create a new release (and tag) with the new package version (see https://github.com/PSPDFKit/PSPDFKit-Cordova/releases).
- [ ] Locally, pull the latest master and publish (`npm publish`) the new release to [npm](https://www.npmjs.com/package/pspdfkit-cordova).
