### PR TITLE
Support image document image save mode

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pspdfkit-cordova",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "PSPDFKit Cordova Plugin for Android and iOS",
   "cordova": {
     "id": "pspdfkit-cordova",

--- a/plugin.xml
+++ b/plugin.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<plugin xmlns="http://apache.org/cordova/ns/plugins/1.0" xmlns:android="http://schemas.android.com/apk/res/android" id="pspdfkit-cordova" version="1.0.2">
+<plugin xmlns="http://apache.org/cordova/ns/plugins/1.0" xmlns:android="http://schemas.android.com/apk/res/android" id="pspdfkit-cordova" version="1.0.3">
   <engines>
     <engine name="cordova" version="&gt;=6.3.1" />
   </engines>

--- a/src/ios/PSPDFKitPlugin.m
+++ b/src/ios/PSPDFKitPlugin.m
@@ -756,6 +756,12 @@ void runOnMainQueueWithoutDeadlocking(void (^block)(void)) {
                   @"SEARCH_MODULAR": @(PSPDFSearchModeModal),
                   @"SEARCH_INLINE": @(PSPDFSearchModeInline)
                 },
+
+            @"PSPDFImageSaveMode":
+
+                @{@"flatten": @(PSPDFImageSaveModeFlatten),
+                  @"flattenAndEmbed": @(PSPDFImageSaveModeFlattenAndEmbed),
+                },
         };
 
         //Note: this method crashes the second time a
@@ -855,6 +861,18 @@ void runOnMainQueueWithoutDeadlocking(void (^block)(void)) {
 - (void)setRenderAnnotationTypesForPSPDFDocumentWithJSON:(NSArray *)options {
     PSPDFAnnotationType types = (PSPDFAnnotationType) [self optionsValueForKeys:options ofType:@"PSPDFAnnotationType" withDefault:PSPDFAnnotationTypeAll];
     _pdfDocument.renderAnnotationTypes = types;
+}
+
+- (void)setImageSaveModeForPSPDFDocumentWithJSON:(NSString *)option {
+    if (![_pdfDocument isKindOfClass:PSPDFImageDocument.class]) { return; }
+    PSPDFImageDocument *imageDocument = (PSPDFImageDocument *)_pdfDocument;
+    imageDocument.imageSaveMode = [self enumValueForKey:option ofType:@"PSPDFImageSaveMode" withDefault:PSPDFImageSaveModeFlattenAndEmbed];
+}
+
+- (NSString *)imageSaveModeAsJSON {
+    if (![_pdfDocument isKindOfClass:PSPDFImageDocument.class]) { return @""; }
+    PSPDFImageDocument *imageDocument = (PSPDFImageDocument *)_pdfDocument;
+    return [self enumKeyForValue:imageDocument.imageSaveMode ofType:@"PSPDFImageSaveMode"];
 }
 
 #pragma mark PSPDFViewController setters and getters


### PR DESCRIPTION
# Details

This adds support for setting and retrieving the `imageSaveMode` of `PSPDFImageDocument`s.

# Acceptance Criteria

- [ ] When approved, right before merging, rebase with master and increment the package version in `package.json` and `plugin.xml`(see example commit: https://github.com/PSPDFKit/PSPDFKit-Cordova/commit/09d5c6b1c12977dc2248c02d869c3247ff5ed6f5).
- [ ] Create a new release (and tag) with the new package version (see https://github.com/PSPDFKit/PSPDFKit-Cordova/releases).
- [ ] Locally, pull the latest master and publish (`npm publish`) the new release to [npm](https://www.npmjs.com/package/pspdfkit-cordova).
