### PR TITLE
Fix Javascript plugin name reference

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pspdfkit-cordova",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "description": "PSPDFKit Cordova Plugin for Android and iOS",
   "cordova": {
     "id": "pspdfkit-cordova",

--- a/plugin.xml
+++ b/plugin.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<plugin xmlns="http://apache.org/cordova/ns/plugins/1.0" xmlns:android="http://schemas.android.com/apk/res/android" id="pspdfkit-cordova" version="1.0.3">
+<plugin xmlns="http://apache.org/cordova/ns/plugins/1.0" xmlns:android="http://schemas.android.com/apk/res/android" id="pspdfkit-cordova" version="1.0.4">
   <engines>
     <engine name="cordova" version="&gt;=6.3.1" />
   </engines>

--- a/src/ios/PSPDFKitPlugin.m
+++ b/src/ios/PSPDFKitPlugin.m
@@ -296,7 +296,7 @@ void runOnMainQueueWithoutDeadlocking(void (^block)(void)) {
     if ([JSON isKindOfClass:[NSDictionary class]]) {
         JSON = [[NSString alloc] initWithData:[NSJSONSerialization dataWithJSONObject:JSON options:0 error:NULL] encoding:NSUTF8StringEncoding];
     }
-    NSString *script = [NSString stringWithFormat:@"PSPDFKitPlugin.dispatchEvent(%@)", JSON];
+    NSString *script = [NSString stringWithFormat:@"PSPDFKit.dispatchEvent(%@)", JSON];
     NSString *result = [self stringByEvaluatingJavaScriptFromString:script];
     return [result length]? [result boolValue]: YES;
 }
@@ -374,11 +374,11 @@ void runOnMainQueueWithoutDeadlocking(void (^block)(void)) {
     if (index == NSNotFound) {
         index = [_pdfController.navigationItem.rightBarButtonItems indexOfObject:sender];
         if (index != NSNotFound) {
-            NSString *script = [NSString stringWithFormat:@"PSPDFKitPlugin.dispatchRightBarButtonAction(%ld)", (long)index];
+            NSString *script = [NSString stringWithFormat:@"PSPDFKit.dispatchRightBarButtonAction(%ld)", (long)index];
             [self stringByEvaluatingJavaScriptFromString:script];
         }
     } else {
-        NSString *script = [NSString stringWithFormat:@"PSPDFKitPlugin.dispatchLeftBarButtonAction(%ld)", (long)index];
+        NSString *script = [NSString stringWithFormat:@"PSPDFKit.dispatchLeftBarButtonAction(%ld)", (long)index];
         [self stringByEvaluatingJavaScriptFromString:script];
     }
 }


### PR DESCRIPTION
# Details

This was causing some event calls to fail.

# Acceptance Criteria

- [x] When approved, right before merging, rebase with master and increment the package version in `package.json` and `plugin.xml`(see example commit: https://github.com/PSPDFKit/PSPDFKit-Cordova/commit/09d5c6b1c12977dc2248c02d869c3247ff5ed6f5).
- [ ] Create a new release (and tag) with the new package version (see https://github.com/PSPDFKit/PSPDFKit-Cordova/releases).
- [ ] Locally, pull the latest master and publish (`npm publish`) the new release to [npm](https://www.npmjs.com/package/pspdfkit-cordova).
