### PR TITLE
Fix AndroidManifest.xml resolution

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pspdfkit-cordova",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "description": "PSPDFKit Cordova Plugin for Android and iOS",
   "cordova": {
     "id": "pspdfkit-cordova",

--- a/plugin.xml
+++ b/plugin.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<plugin xmlns="http://apache.org/cordova/ns/plugins/1.0" xmlns:android="http://schemas.android.com/apk/res/android" id="pspdfkit-cordova" version="1.0.4">
+<plugin xmlns="http://apache.org/cordova/ns/plugins/1.0" xmlns:android="http://schemas.android.com/apk/res/android" id="pspdfkit-cordova" version="1.0.5">
   <engines>
     <engine name="cordova" version="&gt;=6.3.1" />
   </engines>

--- a/plugin.xml
+++ b/plugin.xml
@@ -49,10 +49,10 @@ AND MAY NOT BE RESOLD OR REDISTRIBUTED. USAGE IS BOUND TO THE PSPDFKIT LICENSE A
         <param name="android-package" value="com.pspdfkit.cordova.PSPDFKitPlugin" />
       </feature>
     </config-file>
-    <config-file parent="/*/application" target="app/src/main/AndroidManifest.xml">
+    <config-file parent="/*/application" target="AndroidManifest.xml">
       <meta-data android:name="pspdfkit_license_key" android:value="@string/PSPDFKIT_LICENSE_KEY" />
     </config-file>
-    <config-file parent="/*/application" target="app/src/main/AndroidManifest.xml" after="activity">
+    <config-file parent="/*/application" target="AndroidManifest.xml" after="activity">
       <activity android:name="com.pspdfkit.cordova.CordovaPdfActivity" android:theme="@style/PSPDFKit.Theme" android:windowSoftInputMode="adjustNothing" />
     </config-file>
     <edit-config file="AndroidManifest.xml" target="/manifest/application" mode="merge">


### PR DESCRIPTION
# Details

This PR fixes a failing resolution of the AndroidManifest.xml file, which lead to invalid Android app setup when installing this plugin.

# Acceptance Criteria

- [x] When approved, right before merging, rebase with master and increment the package version in `package.json` and `plugin.xml`(see example commit: https://github.com/PSPDFKit/PSPDFKit-Cordova/commit/09d5c6b1c12977dc2248c02d869c3247ff5ed6f5).
- [ ] Create a new release (and tag) with the new package version (see https://github.com/PSPDFKit/PSPDFKit-Cordova/releases).
- [ ] Locally, pull the latest master and publish (`npm publish`) the new release to [npm](https://www.npmjs.com/package/pspdfkit-cordova).
