### PR TITLE
Expose image document compression quality

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pspdfkit-cordova",
-  "version": "1.0.5",
+  "version": "1.0.6",
   "description": "PSPDFKit Cordova Plugin for Android and iOS",
   "cordova": {
     "id": "pspdfkit-cordova",

--- a/plugin.xml
+++ b/plugin.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<plugin xmlns="http://apache.org/cordova/ns/plugins/1.0" xmlns:android="http://schemas.android.com/apk/res/android" id="pspdfkit-cordova" version="1.0.5">
+<plugin xmlns="http://apache.org/cordova/ns/plugins/1.0" xmlns:android="http://schemas.android.com/apk/res/android" id="pspdfkit-cordova" version="1.0.6">
   <engines>
     <engine name="cordova" version="&gt;=6.3.1" />
   </engines>

--- a/src/ios/PSPDFKitPlugin.m
+++ b/src/ios/PSPDFKitPlugin.m
@@ -875,6 +875,26 @@ void runOnMainQueueWithoutDeadlocking(void (^block)(void)) {
     return [self enumKeyForValue:imageDocument.imageSaveMode ofType:@"PSPDFImageSaveMode"];
 }
 
+- (void)setCompressionQualityForPSPDFDocumentWithJSON:(NSNumber *)option {
+    if (![_pdfDocument isKindOfClass:PSPDFImageDocument.class]) { return; }
+    PSPDFImageDocument *imageDocument = (PSPDFImageDocument *)_pdfDocument;
+    #if CGFLOAT_IS_DOUBLE
+    imageDocument.compressionQuality = option.doubleValue;
+    #else
+    imageDocument.compressionQuality = option.floatValue;
+    #endif
+}
+
+- (NSNumber *)compressionQualityAsJSON {
+    if (![_pdfDocument isKindOfClass:PSPDFImageDocument.class]) { return @""; }
+    PSPDFImageDocument *imageDocument = (PSPDFImageDocument *)_pdfDocument;
+    #if CGFLOAT_IS_DOUBLE
+    return [NSNumber numberWithDouble:imageDocument.compressionQuality];
+    #else
+    return [NSNumber numberWithFloat:imageDocument.compressionQuality];
+    #endif
+}
+
 #pragma mark PSPDFViewController setters and getters
 
 - (void)setPageTransitionForPSPDFViewControllerWithJSON:(NSString *)transition {

--- a/src/ios/PSPDFKitPlugin.m
+++ b/src/ios/PSPDFKitPlugin.m
@@ -886,7 +886,7 @@ void runOnMainQueueWithoutDeadlocking(void (^block)(void)) {
 }
 
 - (NSNumber *)compressionQualityAsJSON {
-    if (![_pdfDocument isKindOfClass:PSPDFImageDocument.class]) { return @""; }
+    if (![_pdfDocument isKindOfClass:PSPDFImageDocument.class]) { return [NSNumber numberWithInteger:NSIntegerMax]; }
     PSPDFImageDocument *imageDocument = (PSPDFImageDocument *)_pdfDocument;
     #if CGFLOAT_IS_DOUBLE
     return [NSNumber numberWithDouble:imageDocument.compressionQuality];


### PR DESCRIPTION
# Details

This adds support for setting and retrieving the `compressionQuality` of `PSPDFImageDocument`s.


# Acceptance Criteria

- [x] When approved, right before merging, rebase with master and increment the package version in `package.json` and `plugin.xml`(see example commit: https://github.com/PSPDFKit/PSPDFKit-Cordova/commit/09d5c6b1c12977dc2248c02d869c3247ff5ed6f5).
- [ ] Create a new release (and tag) with the new package version (see https://github.com/PSPDFKit/PSPDFKit-Cordova/releases).
- [ ] Locally, pull the latest master and publish (`npm publish`) the new release to [npm](https://www.npmjs.com/package/pspdfkit-cordova).
