### PR TITLE
[Android] Add support for image document opening

### DIFF
--- a/src/android/java/com/pspdfkit/cordova/action/document/ShowDocumentAction.java
+++ b/src/android/java/com/pspdfkit/cordova/action/document/ShowDocumentAction.java
@@ -2,6 +2,7 @@ package com.pspdfkit.cordova.action.document;
 
 import android.app.Activity;
 import android.content.ComponentName;
+import android.content.Context;
 import android.content.Intent;
 import android.content.pm.ActivityInfo;
 import android.content.pm.PackageManager;
@@ -22,6 +23,7 @@ import com.pspdfkit.cordova.CordovaPdfActivity;
 import com.pspdfkit.cordova.PSPDFKitPlugin;
 import com.pspdfkit.cordova.PSPDFKitPluginException;
 import com.pspdfkit.cordova.action.BasicAction;
+import com.pspdfkit.document.ImageDocumentUtils;
 import com.pspdfkit.preferences.PSPDFKitPreferences;
 import com.pspdfkit.ui.PdfActivity;
 import com.pspdfkit.ui.PdfActivityIntentBuilder;
@@ -204,12 +206,17 @@ public class ShowDocumentAction extends BasicAction {
       @NonNull final PdfActivityConfiguration configuration,
       @NonNull final CallbackContext callbackContext) {
     final PSPDFKitPlugin plugin = getPlugin();
-    final Intent launchIntent =
-        PdfActivityIntentBuilder.fromUri(plugin.cordova.getContext(), uri)
-            .activityClass(CordovaPdfActivity.class)
-            .passwords(password)
-            .configuration(configuration)
-            .build();
+    final Context context = plugin.cordova.getContext();
+    final PdfActivityIntentBuilder builder =
+        ImageDocumentUtils.isImageUri(context, uri)
+            ? PdfActivityIntentBuilder.fromImageUri(context, uri)
+            : PdfActivityIntentBuilder.fromUri(context, uri)
+                // Only set passwords for PDF documents, since image documents don't support passwords.
+                .passwords(password);
+
+    final Intent launchIntent = builder.activityClass(CordovaPdfActivity.class)
+        .configuration(configuration)
+        .build();
     plugin.cordova.startActivityForResult(getPlugin(), launchIntent, 0);
     callbackContext.success();
   }

--- a/tests/tests.js
+++ b/tests/tests.js
@@ -67,7 +67,23 @@ exports.defineManualTests = function(contentEl, createActionButton) {
     var asset = "www/Guide.pdf";
     var options = {};
     console.log("Opening document " + asset);
-    window.PSPDFKit.showDocumentFromAssets(
+    window.PSPDFKit.presentFromAssets(
+      asset,
+      options,
+      function() {
+        console.log("Document was successfully loaded.");
+      },
+      function(error) {
+        console.log("Error while loading the document:" + error);
+      }
+    );
+  });
+
+  createActionButton("Open Image ocument", function() {
+    var asset = "www/image.jpg";
+    var options = {};
+    console.log("Opening image document " + asset);
+    window.PSPDFKit.presentFromAssets(
       asset,
       options,
       function() {
@@ -94,7 +110,7 @@ exports.defineManualTests = function(contentEl, createActionButton) {
 
     console.log("Opening document " + asset);
 
-    window.PSPDFKit.showDocumentFromAssets(
+    window.PSPDFKit.presentFromAssets(
       asset,
       options,
       function() {
@@ -119,7 +135,7 @@ exports.defineManualTests = function(contentEl, createActionButton) {
 
     console.log("Opening encrypted document " + asset);
 
-    window.PSPDFKit.showDocumentFromAssets(
+    window.PSPDFKit.presentFromAssets(
       asset,
       options,
       function() {


### PR DESCRIPTION
# Details

This PR adds support for image document opening on Android. Both `present()` and `presentFromAssets()` can now handle URIs with image file extensions and will load them as image documents.

# Acceptance Criteria

- [ ] When approved, right before merging, rebase with master and increment the package version in `package.json` and `plugin.xml`(see example commit: https://github.com/PSPDFKit/PSPDFKit-Cordova/commit/09d5c6b1c12977dc2248c02d869c3247ff5ed6f5).
- [ ] Create a new release (and tag) with the new package version (see https://github.com/PSPDFKit/PSPDFKit-Cordova/releases).
- [ ] Locally, pull the latest master and publish (`npm publish`) the new release to [npm](https://www.npmjs.com/package/pspdfkit-cordova).
