### PR TITLE
Fix configuration adapter

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pspdfkit-cordova",
-  "version": "1.0.10",
+  "version": "1.0.11",
   "description": "PSPDFKit Cordova Plugin for Android and iOS",
   "cordova": {
     "id": "pspdfkit-cordova",

--- a/plugin.xml
+++ b/plugin.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<plugin xmlns="http://apache.org/cordova/ns/plugins/1.0" xmlns:android="http://schemas.android.com/apk/res/android" id="pspdfkit-cordova" version="1.0.10">
+<plugin xmlns="http://apache.org/cordova/ns/plugins/1.0" xmlns:android="http://schemas.android.com/apk/res/android" id="pspdfkit-cordova" version="1.0.11">
   <engines>
     <engine name="cordova" version="&gt;=6.3.1" />
   </engines>

--- a/src/android/java/com/pspdfkit/cordova/action/document/ShowDocumentAction.java
+++ b/src/android/java/com/pspdfkit/cordova/action/document/ShowDocumentAction.java
@@ -96,7 +96,7 @@ public class ShowDocumentAction extends BasicAction {
         } else if ("backgroundColor".equals(option)) {
           builder.backgroundColor(Color.parseColor((String) value));
         } else if ("disableAnnotationList".equals(option)) {
-          if (((Boolean) value)) {
+          if ((Boolean) value) {
             builder.disableAnnotationList();
           } else {
             builder.enableAnnotationList();
@@ -104,13 +104,13 @@ public class ShowDocumentAction extends BasicAction {
         } else if ("disableAnnotationNoteHinting".equals(option)) {
           builder.setAnnotationNoteHintingEnabled(!(Boolean) value);
         } else if ("disableBookmarkEditing".equals(option)) {
-          if (((Boolean) value)) {
+          if ((Boolean) value) {
             builder.disableBookmarkEditing();
           } else {
             builder.enableBookmarkEditing();
           }
         } else if ("disableBookmarkList".equals(option)) {
-          if (((Boolean) value)) {
+          if ((Boolean) value) {
             builder.disableBookmarkList();
           } else {
             builder.enableBookmarkList();
@@ -122,25 +122,25 @@ public class ShowDocumentAction extends BasicAction {
             builder.enableCopyPaste();
           }
         } else if ("disableDocumentEditor".equals(option)) {
-          if (((Boolean) value)) {
+          if ((Boolean) value) {
             builder.disableDocumentEditor();
           } else {
             builder.enableDocumentEditor();
           }
         } else if ("disableOutline".equals(option)) {
-          if (((Boolean) value)) {
+          if ((Boolean) value) {
             builder.disableOutline();
           } else {
             builder.enableOutline();
           }
         } else if ("disablePrinting".equals(option)) {
-          if (((Boolean) value)) {
+          if ((Boolean) value) {
             builder.disablePrinting();
           } else {
             builder.enablePrinting();
           }
         } else if ("disableSearch".equals(option)) {
-          if (((Boolean) value)) {
+          if ((Boolean) value) {
             builder.disableSearch();
           } else {
             builder.enableSearch();
@@ -150,19 +150,19 @@ public class ShowDocumentAction extends BasicAction {
         } else if ("disableUndoRedo".equals(option)) {
           builder.undoEnabled(!(Boolean) value);
         } else if ("hidePageLabels".equals(option)) {
-          if (((Boolean) value)) {
+          if ((Boolean) value) {
             builder.hidePageLabels();
           } else {
             builder.showPageLabels();
           }
         } else if ("hidePageNumberOverlay".equals(option)) {
-          if (((Boolean) value)) {
+          if ((Boolean) value) {
             builder.hidePageNumberOverlay();
           } else {
             builder.showPageNumberOverlay();
           }
         } else if ("hideSettingsMenu".equals(option)) {
-          if (((Boolean) value)) {
+          if ((Boolean) value) {
             builder.hideSettingsMenu();
           } else {
             builder.showSettingsMenu();
@@ -171,7 +171,7 @@ public class ShowDocumentAction extends BasicAction {
           final CordovaThumbnailBarMode thumbnailBarMode = CordovaThumbnailBarMode.valueOf((String) value);
           builder.setThumbnailBarMode(thumbnailBarMode.androidThumbnailBarMode);
         } else if ("hideThumbnailGrid".equals(option)) {
-          if (((Boolean) value)) {
+          if ((Boolean) value) {
             builder.hideThumbnailGrid();
           } else {
             builder.showThumbnailGrid();

--- a/src/android/java/com/pspdfkit/cordova/action/document/ShowDocumentAction.java
+++ b/src/android/java/com/pspdfkit/cordova/action/document/ShowDocumentAction.java
@@ -95,39 +95,87 @@ public class ShowDocumentAction extends BasicAction {
           builder.autosaveEnabled((Boolean) value);
         } else if ("backgroundColor".equals(option)) {
           builder.backgroundColor(Color.parseColor((String) value));
-        } else if ("disableAnnotationList".equals(option) && ((Boolean) value)) {
-          builder.disableAnnotationList();
+        } else if ("disableAnnotationList".equals(option)) {
+          if (((Boolean) value)) {
+            builder.disableAnnotationList();
+          } else {
+            builder.enableAnnotationList();
+          }
         } else if ("disableAnnotationNoteHinting".equals(option)) {
           builder.setAnnotationNoteHintingEnabled(!(Boolean) value);
-        } else if ("disableBookmarkEditing".equals(option) && ((Boolean) value)) {
-          builder.disableBookmarkEditing();
-        } else if ("disableBookmarkList".equals(option) && ((Boolean) value)) {
-          builder.disableBookmarkList();
+        } else if ("disableBookmarkEditing".equals(option)) {
+          if (((Boolean) value)) {
+            builder.disableBookmarkEditing();
+          } else {
+            builder.enableBookmarkEditing();
+          }
+        } else if ("disableBookmarkList".equals(option)) {
+          if (((Boolean) value)) {
+            builder.disableBookmarkList();
+          } else {
+            builder.enableBookmarkList();
+          }
         } else if ("disableCopyPaste".equals(option)) {
-          if ((Boolean) value) builder.disableCopyPaste();
-          else builder.enableCopyPaste();
-        } else if ("disableDocumentEditor".equals(option) && ((Boolean) value)) {
-          builder.disableDocumentEditor();
-        } else if ("disableOutline".equals(option) && ((Boolean) value)) {
-          builder.disableOutline();
-        } else if ("disablePrinting".equals(option) && ((Boolean) value)) {
-          builder.disablePrinting();
-        } else if ("disableSearch".equals(option) && ((Boolean) value)) {
-          builder.disableSearch();
+          if ((Boolean) value) {
+            builder.disableCopyPaste();
+          } else {
+            builder.enableCopyPaste();
+          }
+        } else if ("disableDocumentEditor".equals(option)) {
+          if (((Boolean) value)) {
+            builder.disableDocumentEditor();
+          } else {
+            builder.enableDocumentEditor();
+          }
+        } else if ("disableOutline".equals(option)) {
+          if (((Boolean) value)) {
+            builder.disableOutline();
+          } else {
+            builder.enableOutline();
+          }
+        } else if ("disablePrinting".equals(option)) {
+          if (((Boolean) value)) {
+            builder.disablePrinting();
+          } else {
+            builder.enablePrinting();
+          }
+        } else if ("disableSearch".equals(option)) {
+          if (((Boolean) value)) {
+            builder.disableSearch();
+          } else {
+            builder.enableSearch();
+          }
         } else if ("shareFeatures".equals(option)) {
           builder.setEnabledShareFeatures(parseShareFeatures((JSONArray) value));
         } else if ("disableUndoRedo".equals(option)) {
           builder.undoEnabled(!(Boolean) value);
-        } else if ("hidePageLabels".equals(option) && ((Boolean) value)) {
-          builder.hidePageLabels();
-        } else if ("hidePageNumberOverlay".equals(option) && ((Boolean) value)) {
-          builder.hidePageNumberOverlay();
-        } else if ("hideSettingsMenu".equals(option) && ((Boolean) value)) {
-          builder.hideSettingsMenu();
+        } else if ("hidePageLabels".equals(option)) {
+          if (((Boolean) value)) {
+            builder.hidePageLabels();
+          } else {
+            builder.showPageLabels();
+          }
+        } else if ("hidePageNumberOverlay".equals(option)) {
+          if (((Boolean) value)) {
+            builder.hidePageNumberOverlay();
+          } else {
+            builder.showPageNumberOverlay();
+          }
+        } else if ("hideSettingsMenu".equals(option)) {
+          if (((Boolean) value)) {
+            builder.hideSettingsMenu();
+          } else {
+            builder.showSettingsMenu();
+          }
         } else if ("thumbnailBarMode".equals(option)) {
-          builder.setThumbnailBarMode(ThumbnailBarMode.valueOf((String) value));
-        } else if ("hideThumbnailGrid".equals(option) && ((Boolean) value)) {
-          builder.hideThumbnailGrid();
+          final CordovaThumbnailBarMode thumbnailBarMode = CordovaThumbnailBarMode.valueOf((String) value);
+          builder.setThumbnailBarMode(thumbnailBarMode.androidThumbnailBarMode);
+        } else if ("hideThumbnailGrid".equals(option)) {
+          if (((Boolean) value)) {
+            builder.hideThumbnailGrid();
+          } else {
+            builder.showThumbnailGrid();
+          }
         } else if ("memoryCacheSize".equals(option)) {
           builder.memoryCacheSize((Integer) value);
         } else if ("pageFitMode".equals(option)) {
@@ -211,13 +259,31 @@ public class ShowDocumentAction extends BasicAction {
         ImageDocumentUtils.isImageUri(context, uri)
             ? PdfActivityIntentBuilder.fromImageUri(context, uri)
             : PdfActivityIntentBuilder.fromUri(context, uri)
-                // Only set passwords for PDF documents, since image documents don't support passwords.
-                .passwords(password);
+            // Only set passwords for PDF documents, since image documents don't support passwords.
+            .passwords(password);
 
     final Intent launchIntent = builder.activityClass(CordovaPdfActivity.class)
         .configuration(configuration)
         .build();
     plugin.cordova.startActivityForResult(getPlugin(), launchIntent, 0);
     callbackContext.success();
+  }
+
+  /**
+   * Cordova representation of the PSPDFKit thumbnail bar mode, that maps to the Android specific
+   * thumbnail bar mode. This is here, to map the cross-platform API we provide in JavaScript to the
+   * Android API. Values in this enum match the {@code ThumbnailBarMode} that is defined inside the
+   * {@code PSPDFKit.js} file.
+   */
+  private enum CordovaThumbnailBarMode {
+    THUMBNAIL_BAR_MODE_DEFAULT(ThumbnailBarMode.THUMBNAIL_BAR_MODE_FLOATING),
+    THUMBNAIL_BAR_MODE_SCROLLABLE(ThumbnailBarMode.THUMBNAIL_BAR_MODE_SCROLLABLE),
+    THUMBNAIL_BAR_MODE_NONE(ThumbnailBarMode.THUMBNAIL_BAR_MODE_NONE);
+
+    public final ThumbnailBarMode androidThumbnailBarMode;
+
+    CordovaThumbnailBarMode(ThumbnailBarMode androidThumbnailBarMode) {
+      this.androidThumbnailBarMode = androidThumbnailBarMode;
+    }
   }
 }


### PR DESCRIPTION
# Details

Resolves #24. Some of our configuration options where behaving unexpectedly when used with the default options. This also fixes the mapping between thumbnail bar enum types that was no longer correct since we merged public iOS and Android APIs.

# Acceptance Criteria

- [x] When approved, right before merging, rebase with master and increment the package version in `package.json` and `plugin.xml`(see example commit: https://github.com/PSPDFKit/PSPDFKit-Cordova/commit/09d5c6b1c12977dc2248c02d869c3247ff5ed6f5).
- [ ] Create a new release (and tag) with the new package version (see https://github.com/PSPDFKit/PSPDFKit-Cordova/releases).
- [ ] Locally, pull the latest master and publish (`npm publish`) the new release to [npm](https://www.npmjs.com/package/pspdfkit-cordova).
