### PR TITLE
Add `setGlobalOptions()` on iOS

### DIFF
--- a/src/ios/PSPDFKitPlugin.m
+++ b/src/ios/PSPDFKitPlugin.m
@@ -593,6 +593,30 @@ void runOnMainQueueWithoutDeadlocking(void (^block)(void)) {
     }
 }
 
+- (PSPDFSettingKey)settingKeyFromString:(NSString *)settingKeyString {
+    if ([settingKeyString isEqualToString:@"PSPDFSettingKeyXCallbackURLString"]) {
+        return PSPDFSettingKeyXCallbackURLString;
+    } else if ([settingKeyString isEqualToString:@"PSPDFSettingKeyApplicationPolicy"]) {
+        return PSPDFSettingKeyApplicationPolicy;
+    } else if ([settingKeyString isEqualToString:@"PSPDFSettingKeyFileManager"]) {
+        return PSPDFSettingKeyFileManager;
+    } else if ([settingKeyString isEqualToString:@"PSPDFSettingKeyCoordinatedFileManager"]) {
+        return PSPDFSettingKeyCoordinatedFileManager;
+    } else if ([settingKeyString isEqualToString:@"PSPDFSettingKeyFileCoordinationEnabled"]) {
+        return PSPDFSettingKeyFileCoordinationEnabled;
+    } else if ([settingKeyString isEqualToString:@"PSPDFSettingKeyLibraryIndexingPriority"]) {
+        return PSPDFSettingKeyLibraryIndexingPriority;
+    } else if ([settingKeyString isEqualToString:@"PSPDFSettingKeyDebugMode"]) {
+        return PSPDFSettingKeyDebugMode;
+    } else if ([settingKeyString isEqualToString:@"PSPDFSettingKeyAdditionalFontDirectories"]) {
+        return PSPDFSettingKeyAdditionalFontDirectories;
+    } else if ([settingKeyString isEqualToString:@"PSPDFSettingKeyHonorDocumentPermissions"]) {
+        return PSPDFSettingKeyHonorDocumentPermissions;
+    } else {
+        return nil;
+    }
+}
+
 #pragma mark Enums and options
 
 - (NSDictionary *)enumValuesOfType:(NSString *)type {
@@ -796,6 +820,18 @@ void runOnMainQueueWithoutDeadlocking(void (^block)(void)) {
     }
 }
 
+- (void)setGlobalOptions:(CDVInvokedUrlCommand *)command {
+    NSDictionary *options = [command argumentAtIndex:0];
+    if (options) {
+        for (NSString *key in options.allKeys) {
+            [PSPDFKitGlobal.sharedInstance setValue:options[key] forKey:[self settingKeyFromString:key]];
+        }
+        [self.commandDelegate sendPluginResult:[CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsBool:YES] callbackId:command.callbackId];
+    } else {
+        [self.commandDelegate sendPluginResult:[CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR messageAsString:@"Invalid License Key"] callbackId:command.callbackId];
+    }
+}
+
 #pragma mark PSPDFDocument setters and getters
 
 - (void)setFileURLForPSPDFDocumentWithJSON:(NSString *)path {
@@ -888,21 +924,21 @@ void runOnMainQueueWithoutDeadlocking(void (^block)(void)) {
 - (void)setCompressionQualityForPSPDFDocumentWithJSON:(NSNumber *)option {
     if (![_pdfDocument isKindOfClass:PSPDFImageDocument.class]) { return; }
     PSPDFImageDocument *imageDocument = (PSPDFImageDocument *)_pdfDocument;
-    #if CGFLOAT_IS_DOUBLE
+#if CGFLOAT_IS_DOUBLE
     imageDocument.compressionQuality = option.doubleValue;
-    #else
+#else
     imageDocument.compressionQuality = option.floatValue;
-    #endif
+#endif
 }
 
 - (NSNumber *)compressionQualityAsJSON {
     if (![_pdfDocument isKindOfClass:PSPDFImageDocument.class]) { return [NSNumber numberWithInteger:NSIntegerMax]; }
     PSPDFImageDocument *imageDocument = (PSPDFImageDocument *)_pdfDocument;
-    #if CGFLOAT_IS_DOUBLE
+#if CGFLOAT_IS_DOUBLE
     return [NSNumber numberWithDouble:imageDocument.compressionQuality];
-    #else
+#else
     return [NSNumber numberWithFloat:imageDocument.compressionQuality];
-    #endif
+#endif
 }
 
 #pragma mark PSPDFViewController setters and getters

--- a/src/ios/PSPDFKitPlugin.m
+++ b/src/ios/PSPDFKitPlugin.m
@@ -821,14 +821,14 @@ void runOnMainQueueWithoutDeadlocking(void (^block)(void)) {
 }
 
 - (void)setGlobalOptions:(CDVInvokedUrlCommand *)command {
-    NSDictionary *options = [command argumentAtIndex:0];
+    NSDictionary<NSString *,id> *options = [command argumentAtIndex:0];
     if (options) {
         for (NSString *key in options.allKeys) {
             [PSPDFKitGlobal.sharedInstance setValue:options[key] forKey:[self settingKeyFromString:key]];
         }
         [self.commandDelegate sendPluginResult:[CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsBool:YES] callbackId:command.callbackId];
     } else {
-        [self.commandDelegate sendPluginResult:[CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR messageAsString:@"Invalid License Key"] callbackId:command.callbackId];
+        [self.commandDelegate sendPluginResult:[CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR messageAsString:@"No options provided."] callbackId:command.callbackId];
     }
 }
 

--- a/www/PSPDFKit.js
+++ b/www/PSPDFKit.js
@@ -33,6 +33,24 @@ exports.setLicenseKey = function(key, callback) {
   }
 };
 
+/**
+ * Sets global options for PSPDFKit.
+ *
+ * @param options The `options` parameter. See the full list of `PSPDFSettingKeys` here: https://pspdfkit.com/api/ios/Other%20Constants.html#/c:@PSPDFSettingKeyXCallbackURLString
+ * @callback callback Success and error callback function.
+ *
+ * __Supported Platforms__
+ *
+ * -iOS
+ */
+exports.setGlobalOptions = function (options, callback) {
+  if (platform === "ios") {
+    executeAction(callback, "setGlobalOptions", [options]);
+  } else {
+    console.log("Not implemented on " + platform + ".");
+  }
+};
+
 // Showing and dismissing PDF
 
 /**


### PR DESCRIPTION
Came up in Z-18520.

---

# Details

This PR adds the ability to set the global options for PSPDFKit for iOS.

### Usage:


```js
PSPDFKit.setGlobalOptions({ "PSPDFSettingKeyHonorDocumentPermissions": false });
```

# Acceptance Criteria

- [x] Add the ability to set the global options for PSPDFKit for iOS.
- [ ] When approved, right before merging, rebase with master and increment the package version in `package.json` and `plugin.xml`(see example commit: https://github.com/PSPDFKit/PSPDFKit-Cordova/commit/09d5c6b1c12977dc2248c02d869c3247ff5ed6f5).
- [ ] Create a new release (and tag) with the new package version (see https://github.com/PSPDFKit/PSPDFKit-Cordova/releases).
- [ ] Locally, pull the latest master and publish (`npm publish`) the new release to [npm](https://www.npmjs.com/package/pspdfkit-cordova).
