### PR TITLE
Update for PSPDFKit 9.5 for iOS

### DIFF
--- a/docs/ios/README.md
+++ b/docs/ios/README.md
@@ -7,8 +7,9 @@ PSPDFKit comes with open source plugins for Cordova on both [iOS](https://pspdfk
 ## Requirements
 
 - Xcode 11.5 or later
-- PSPDFKit 9.4.0 for iOS or later
-- Cordova >= 9.0.0
+- PSPDFKit 9.5.0 for iOS or later
+- Cordova Lib >= 9.0.0
+- Cordova iOS >= 5.1.1
 - CocoaPods >= 1.9.3
 
 ## Installation

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pspdfkit-cordova",
-  "version": "1.0.15",
+  "version": "1.0.16",
   "description": "PSPDFKit Cordova Plugin for Android and iOS",
   "cordova": {
     "id": "pspdfkit-cordova",

--- a/plugin.xml
+++ b/plugin.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<plugin xmlns="http://apache.org/cordova/ns/plugins/1.0" xmlns:android="http://schemas.android.com/apk/res/android" id="pspdfkit-cordova" version="1.0.15">
+<plugin xmlns="http://apache.org/cordova/ns/plugins/1.0" xmlns:android="http://schemas.android.com/apk/res/android" id="pspdfkit-cordova" version="1.0.16">
   <engines>
     <engine name="cordova" version="&gt;=6.3.1" />
   </engines>

--- a/src/ios/PSPDFKitPlugin.m
+++ b/src/ios/PSPDFKitPlugin.m
@@ -481,11 +481,11 @@ void runOnMainQueueWithoutDeadlocking(void (^block)(void)) {
 
     // Setup gesture recognizers.
     UITapGestureRecognizer *tapGestureRecognizer = [[UITapGestureRecognizer alloc] initWithTarget:self action:@selector(tapGestureRecognizerDidChangeState:)];
-    [_pdfController.documentViewController.interactions.allInteractions allowSimultaneousRecognitionWithGestureRecognizer:tapGestureRecognizer];
+    [_pdfController.interactions.allInteractions allowSimultaneousRecognitionWithGestureRecognizer:tapGestureRecognizer];
     [_pdfController.view addGestureRecognizer:tapGestureRecognizer];
 
     UILongPressGestureRecognizer *longPressGestureRecognizer = [[UILongPressGestureRecognizer alloc] initWithTarget:self action:@selector(longPressGestureRecognizerDidChangeState:)];
-    [_pdfController.documentViewController.interactions.allInteractions allowSimultaneousRecognitionWithGestureRecognizer:longPressGestureRecognizer];
+    [_pdfController.interactions.allInteractions allowSimultaneousRecognitionWithGestureRecognizer:longPressGestureRecognizer];
     [_pdfController.view addGestureRecognizer:longPressGestureRecognizer];
 }
 
@@ -1591,7 +1591,7 @@ static NSString *PSPDFStringFromCGRect(CGRect rect) {
 #pragma mark - UIGestureRecognizerDelegate
 
 - (BOOL)gestureRecognizerShouldBegin:(UIGestureRecognizer *)gestureRecognizer {
-    return [_pdfController.documentViewController.interactions.allAnnotationInteractions canActivateAtPoint:[gestureRecognizer locationInView:_pdfController.view] inCoordinateSpace:_pdfController.view];
+    return [_pdfController.interactions.allAnnotationInteractions canActivateAtPoint:[gestureRecognizer locationInView:_pdfController.view] inCoordinateSpace:_pdfController.view];
 }
 
 #pragma mark - Gesture Recognizers

--- a/src/ios/PSPDFKitPlugin.m
+++ b/src/ios/PSPDFKitPlugin.m
@@ -283,6 +283,12 @@
 #else
     if ([self.webView isKindOfClass:UIWebView.class]) {
         result = [(UIWebView *)self.webView stringByEvaluatingJavaScriptFromString:script];
+    } else if ([self.webView isKindOfClass:WKWebView.class]) {
+        runOnMainQueueWithoutDeadlocking(^{
+            [((WKWebView *)self.webView) evaluateJavaScript:script completionHandler:^(id resultID, NSError *error) {
+                result = [resultID description];
+            }];
+        });
     }
 #endif
     return result;

--- a/src/ios/PSPDFKitPlugin.m
+++ b/src/ios/PSPDFKitPlugin.m
@@ -272,15 +272,19 @@
 
 - (NSString *)stringByEvaluatingJavaScriptFromString:(NSString *)script {
     __block NSString *result;
-    if ([self.webView isKindOfClass:UIWebView.class]) {
-        result = [(UIWebView *)self.webView stringByEvaluatingJavaScriptFromString:script];
-    } else {
+#if WK_WEB_VIEW_ONLY
+    if ([self.webView isKindOfClass:WKWebView.class]) {
         runOnMainQueueWithoutDeadlocking(^{
             [((WKWebView *)self.webView) evaluateJavaScript:script completionHandler:^(id resultID, NSError *error) {
                 result = [resultID description];
             }];
         });
     }
+#else
+    if ([self.webView isKindOfClass:UIWebView.class]) {
+        result = [(UIWebView *)self.webView stringByEvaluatingJavaScriptFromString:script];
+    }
+#endif
     return result;
 }
 


### PR DESCRIPTION
⚠️ Only merge after PSPDFKit 9.5 for iOS is released ⚠️ 

---

# Details

This PR updates for the upcoming PSPDFKit 9.5 release:

1. https://github.com/PSPDFKit/PSPDFKit-Cordova/commit/795ac801be1f3d94d8894197d7198a14b03e4284 and [`676c749` (#30)](https://github.com/PSPDFKit/PSPDFKit-Cordova/pull/30/commits/676c749c6fc60c9b9ab2ab964949cb0b1c0cb9d7) will allow users to disable (remove at compile time) the use of `UIWebView` via the `cordova-plugin-wkwebview-engine` plugin. See https://github.com/apache/cordova-ios/issues/661#issuecomment-599500855 for more details.

2. https://github.com/PSPDFKit/PSPDFKit-Cordova/commit/c59f32699557b79ea360d662aded0c0afc9f073e adds custom gesture recognizers for tap and long press to migrate away from deprecated methods in v9.5.

# Acceptance Criteria

- [x] Test the integration in a new Cordova project on iOS.
- [x] Test the integration in a new Ionic project on iOS.
- [x] When approved, right before merging, rebase with master and increment the package version in `package.json` and `plugin.xml`(see example commit: https://github.com/PSPDFKit/PSPDFKit-Cordova/commit/09d5c6b1c12977dc2248c02d869c3247ff5ed6f5).
- [ ] Create a new release (and tag) with the new package version (see https://github.com/PSPDFKit/PSPDFKit-Cordova/releases).
- [ ] Locally, pull the latest master and publish (`npm publish`) the new release to [npm](https://www.npmjs.com/package/pspdfkit-cordova).
