### PR TITLE
PSPDFKit 6.5 for Android update

### DIFF
--- a/docs/android/README.md
+++ b/docs/android/README.md
@@ -9,7 +9,7 @@ This plugin defines a global `PSPDFKit` object, which provides an API for viewin
 ## Requirements
 - Android SDK API level 19+ / Android 4.4+ (KitKat)
 - Cordova Android 8+.
-- PSPDFKit for Android v6.0.1
+- PSPDFKit for Android 6.5
 
 ## Installation
 
@@ -150,12 +150,9 @@ cordova platform add android
 cordova plugin add https://github.com/PSPDFKit/PSPDFKit-Cordova.git
 ```
 
-4. Next you need to setup your PSPDFKit license key and Maven password. If you don't have a license key or Maven password yet, you can get them by requesting an evaluation version of PSPDFKit at https://pspdfkit.com/try. Inside your Android app's `platforms/android/local.properties` file, specify the `pspdfkit.password` and `pspdfkit.license` properties.:
+4. Next you need to setup your PSPDFKit license key. If you don't have a license key yet, you can get one by requesting an evaluation version of PSPDFKit at https://pspdfkit.com/try. Inside your Android app's `platforms/android/local.properties` file, specify the `pspdfkit.license` property:
 
 ```properties
-# This is the MAVEN_KEY you received when requesting a demo or from the customer portal.
-pspdfkit.password=YOUR_PASSWORD
-
 # This is the LICENSE_KEY you received when requesting a demo or from the customer portal.
 pspdfkit.license=LICENSE_STRING
 ```
@@ -209,12 +206,9 @@ ionic cordova platform add android
 ionic cordova plugin add https://github.com/PSPDFKit/PSPDFKit-Cordova.git
 ```
 
-4. Next you need to setup your PSPDFKit license key and Maven password. If you don't have a license key or Maven password yet, you can get them by requesting an evaluation version of PSPDFKit at https://pspdfkit.com/try. Specify the `pspdfkit.password` and `pspdfkit.license` properties inside your Android app's `platforms/android/local.properties` file, create the file if it does not exist:
+4. Next you need to set up your PSPDFKit license key. If you don't have a license key yet, you can get one by requesting an evaluation version of PSPDFKit at https://pspdfkit.com/try. Specify the `pspdfkit.license` property inside your Android app's `platforms/android/local.properties` file, create the file if it does not exist:
 
 ```properties
-# This is the MAVEN_KEY you received when requesting a demo or from the customer portal.
-pspdfkit.password=YOUR_PASSWORD
-
 # This is the LICENSE_KEY you received when requesting a demo or from the customer portal.
 pspdfkit.license=LICENSE_STRING
 ```
@@ -283,6 +277,7 @@ You can find the API documentation in [PSPDFKit.js](../../www/PSPDFKit.js).
 ## Troubleshooting
 
 ### Error Reporting
+
 To get proper error reporting for JavaScript exceptions, you need to register a global error listener which will print most runtime errors to Logcat.
 
 Put the following code snippet into `[your-project]/platforms⁩/android⁩/app⁩/src⁩/main⁩/assets⁩/⁨www⁩/js⁩/index.js`:

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pspdfkit-cordova",
-  "version": "1.0.16",
+  "version": "1.0.17",
   "description": "PSPDFKit Cordova Plugin for Android and iOS",
   "cordova": {
     "id": "pspdfkit-cordova",

--- a/plugin.xml
+++ b/plugin.xml
@@ -117,8 +117,6 @@ There's only on more step to get you started:
 
     pspdfkit.license = YOUR_PSPDFKIT_LICENSE
 
-    2) Inside your `project.properties` you need to set the `target` to `android-28`.
-
     Make sure to replace YOUR_PSPDFKIT_LICENSE with the actual PSPDFKit license string that you
     received while requesting a demo at https://pspdfkit.com/try/ or via the 
     PSPDFKit customer portal (in case you already own a license).

--- a/plugin.xml
+++ b/plugin.xml
@@ -115,14 +115,13 @@ There's only on more step to get you started:
 
     1) You need to add following lines to the `local.properties` (usually inside platforms/android/): 
 
-    pspdfkit.password = YOUR_PASSWORD
     pspdfkit.license = YOUR_PSPDFKIT_LICENSE
 
     2) Inside your `project.properties` you need to set the `target` to `android-28`.
 
-    Make sure to replace YOUR_PASSWORD and YOUR_PSPDFKIT_LICENSE with the actual PSPDFKit customer password
-    and license string that you received while requesting a demo at https://pspdfkit.com/try/ or via the PSPDFKit 
-    customer portal (in case you already own a license).
+    Make sure to replace YOUR_PSPDFKIT_LICENSE with the actual PSPDFKit license string that you
+    received while requesting a demo at https://pspdfkit.com/try/ or via the 
+    PSPDFKit customer portal (in case you already own a license).
 
 For the complete documentation and troubleshooting, check out our documentation at https://github.com/PSPDFKit/PSPDFKit-Cordova. 
 In case there are issues, feel free to reach out to our support team at https://pspdfkit.com/support/request/.

--- a/plugin.xml
+++ b/plugin.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<plugin xmlns="http://apache.org/cordova/ns/plugins/1.0" xmlns:android="http://schemas.android.com/apk/res/android" id="pspdfkit-cordova" version="1.0.16">
+<plugin xmlns="http://apache.org/cordova/ns/plugins/1.0" xmlns:android="http://schemas.android.com/apk/res/android" id="pspdfkit-cordova" version="1.0.17">
   <engines>
     <engine name="cordova" version="&gt;=6.3.1" />
   </engines>

--- a/src/android/config.gradle
+++ b/src/android/config.gradle
@@ -20,19 +20,6 @@ if (pspdfkitMavenUrl == null || pspdfkitMavenUrl == '') {
     ext.pspdfkitMavenUrl = 'https://customers.pspdfkit.com/maven/'
 }
 
-ext.pspdfkitUsername = localProperties.getProperty('pspdfkit.username')
-if (pspdfkitUsername == null || pspdfkitUsername == '') {
-    ext.pspdfkitUsername = 'pspdfkit'
-}
-
-ext.pspdfkitPassword = localProperties.getProperty('pspdfkit.password')
-if (pspdfkitPassword == null || pspdfkitPassword == '') {
-    throw new GradleException("PSPDFKit password was not specified. The password is required to download the PSPDFKit AAR file from PSPDFKit servers"
-        + " into your project. Please specify as pspdfkit.password inside the local.properties file. In case you don't own a password for PSPDFKit"
-        + " yet, you can request an evaluation copy of PSPDFKit at https://pspdfkit.com/try/. If you already own a license of PSPDFKit, you can"
-        + " access it at https://customers.pspdfkit.com/.")
-}
-
 ext.pspdfkitLicense = localProperties.getProperty('pspdfkit.license')
 if (pspdfkitLicense == null || pspdfkitLicense == '') {
     throw new GradleException("PSPDFKit license was not specified. The license is required to initialize and run PSPDFKit."
@@ -44,5 +31,5 @@ if (pspdfkitLicense == null || pspdfkitLicense == '') {
 ext.pspdfkitMavenModuleName = 'pspdfkit'
 ext.pspdfkitVersion = localProperties.getProperty('pspdfkit.version')
 if (pspdfkitVersion == null || pspdfkitVersion == '') {
-    ext.pspdfkitVersion = '6.4.0'
+    ext.pspdfkitVersion = '6.5.0'
 }

--- a/src/android/pspdfkit.gradle
+++ b/src/android/pspdfkit.gradle
@@ -10,12 +10,6 @@
 repositories {
     maven {
         url pspdfkitMavenUrl
-        credentials {
-            username pspdfkitUsername
-            // The PSPDFKit password has to be specified in your app's local.properties file, for example:
-            // pspdfkit.password = MY_PSPDFKIT_PASSWORD
-            password pspdfkitPassword
-        }
     }
     maven {
         url "https://maven.google.com"


### PR DESCRIPTION
# Details

This PR updates the wrapper to PSPDFKit 6.5 for Android. Furthermore, it removes the need for Maven credentials, which are no longer required for downloading PSPDFKit.

# Acceptance Criteria

- [x] When approved, right before merging, rebase with master and increment the package version in `package.json` and `plugin.xml`(see example commit: https://github.com/PSPDFKit/PSPDFKit-Cordova/commit/09d5c6b1c12977dc2248c02d869c3247ff5ed6f5).
- [ ] Create a new release (and tag) with the new package version (see https://github.com/PSPDFKit/PSPDFKit-Cordova/releases).
- [ ] Locally, pull the latest master and publish (`npm publish`) the new release to [npm](https://www.npmjs.com/package/pspdfkit-cordova).
