### PR TITLE
Add annotations events on iOS

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pspdfkit-cordova",
-  "version": "1.0.17",
+  "version": "1.0.18",
   "description": "PSPDFKit Cordova Plugin for Android and iOS",
   "cordova": {
     "id": "pspdfkit-cordova",

--- a/plugin.xml
+++ b/plugin.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<plugin xmlns="http://apache.org/cordova/ns/plugins/1.0" xmlns:android="http://schemas.android.com/apk/res/android" id="pspdfkit-cordova" version="1.0.17">
+<plugin xmlns="http://apache.org/cordova/ns/plugins/1.0" xmlns:android="http://schemas.android.com/apk/res/android" id="pspdfkit-cordova" version="1.0.18">
   <engines>
     <engine name="cordova" version="&gt;=6.3.1" />
   </engines>

--- a/src/ios/PSPDFKitPlugin.m
+++ b/src/ios/PSPDFKitPlugin.m
@@ -487,6 +487,11 @@ void runOnMainQueueWithoutDeadlocking(void (^block)(void)) {
     UILongPressGestureRecognizer *longPressGestureRecognizer = [[UILongPressGestureRecognizer alloc] initWithTarget:self action:@selector(longPressGestureRecognizerDidChangeState:)];
     [_pdfController.interactions.allInteractions allowSimultaneousRecognitionWithGestureRecognizer:longPressGestureRecognizer];
     [_pdfController.view addGestureRecognizer:longPressGestureRecognizer];
+
+    // Notifications
+    [NSNotificationCenter.defaultCenter addObserver:self selector:@selector(annotationChangedNotification:) name:PSPDFAnnotationsAddedNotification object:nil];
+    [NSNotificationCenter.defaultCenter addObserver:self selector:@selector(annotationChangedNotification:) name:PSPDFAnnotationChangedNotification object:nil];
+    [NSNotificationCenter.defaultCenter addObserver:self selector:@selector(annotationChangedNotification:) name:PSPDFAnnotationsRemovedNotification object:nil];
 }
 
 - (PSPDFDocument *)createXFDFDocumentWithPath:(NSString *)xfdfFilePath {
@@ -1730,7 +1735,7 @@ static NSString *PSPDFStringFromCGRect(CGRect rect) {
 
 #pragma mark - Helper
 
-+ (NSArray <NSDictionary *> *)instantJSONFromAnnotations:(NSArray <PSPDFAnnotation *> *) annotations {
++ (NSArray <NSDictionary *> *)instantJSONFromAnnotations:(NSArray <PSPDFAnnotation *> *)annotations {
     NSMutableArray <NSDictionary *> *annotationsJSON = [NSMutableArray new];
     for (PSPDFAnnotation *annotation in annotations) {
         NSDictionary <NSString *, NSString *> *uuidDict = @{@"uuid" : annotation.uuid};
@@ -1967,6 +1972,35 @@ static NSString *PSPDFStringFromCGRect(CGRect rect) {
         CDVPluginResult *pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR
                                                       messageAsDictionary:@{@"localizedDescription": error.localizedDescription, @"domain": error.domain}];
         [self.commandDelegate sendPluginResult:pluginResult callbackId:command.callbackId];
+    }
+}
+
+#pragma mark - Notifications
+
+- (void)annotationChangedNotification:(NSNotification *)notification {
+    id object = notification.object;
+    NSArray <PSPDFAnnotation *> *annotations;
+    if ([object isKindOfClass:NSArray.class]) {
+        annotations = object;
+    } else if ([object isKindOfClass:PSPDFAnnotation.class]) {
+        annotations = @[object];
+    } else {
+        return;
+    }
+
+    NSString *name = notification.name;
+    NSString *changeEventName;
+    if ([name isEqualToString:PSPDFAnnotationChangedNotification]) {
+        changeEventName = @"onAnnotationChanged";
+    } else if ([name isEqualToString:PSPDFAnnotationsAddedNotification]) {
+        changeEventName = @"onAnnotationsAdded";
+    } else if ([name isEqualToString:PSPDFAnnotationsRemovedNotification]) {
+        changeEventName = @"onAnnotationsRemoved";
+    }
+
+    NSArray <NSDictionary *> *annotationsJSON = [PSPDFKitPlugin instantJSONFromAnnotations:annotations];
+    if (annotationsJSON) {
+        [self sendEventWithJSON:@{@"type": changeEventName, @"annotations": annotationsJSON}];
     }
 }
 

--- a/src/ios/PSPDFKitPlugin.m
+++ b/src/ios/PSPDFKitPlugin.m
@@ -1991,7 +1991,7 @@ static NSString *PSPDFStringFromCGRect(CGRect rect) {
     NSString *name = notification.name;
     NSString *changeEventName;
     if ([name isEqualToString:PSPDFAnnotationChangedNotification]) {
-        changeEventName = @"onAnnotationChanged";
+        changeEventName = @"onAnnotationsChanged";
     } else if ([name isEqualToString:PSPDFAnnotationsAddedNotification]) {
         changeEventName = @"onAnnotationsAdded";
     } else if ([name isEqualToString:PSPDFAnnotationsRemovedNotification]) {


### PR DESCRIPTION
# Details

This PR adds `onAnnotationChanged`, `onAnnotationsAdded `, and `onAnnotationsRemoved` events on iOS.

Came up in `Z#20082`.

## Usage:

```js
PSPDFKit.addEventListener('onAnnotationsChanged', function(event){
  console.log('Changed annotations: ' + JSON.stringify(event["annotations"]));
});

PSPDFKit.addEventListener('onAnnotationsAdded', function(event){
  console.log('Added annotations: ' + JSON.stringify(event["annotations"]));
});

PSPDFKit.addEventListener('onAnnotationsRemoved', function(event){
  console.log('Removed annotations: ' + JSON.stringify(event["annotations"]));
});
```

# Acceptance Criteria

- [x] Events for adding, removing, and changing annotations are added.
- [x] When approved, right before merging, rebase with master and increment the package version in `package.json` and `plugin.xml`(see example commit: https://github.com/PSPDFKit/PSPDFKit-Cordova/commit/09d5c6b1c12977dc2248c02d869c3247ff5ed6f5).
- [ ] Create a new release (and tag) with the new package version (see https://github.com/PSPDFKit/PSPDFKit-Cordova/releases).
- [ ] Locally, pull the latest master and publish (`npm publish`) the new release to [npm](https://www.npmjs.com/package/pspdfkit-cordova).
