### PR TITLE
Update for PSPDFKit 10 for iOS

### DIFF
--- a/docs/ios/README.md
+++ b/docs/ios/README.md
@@ -10,7 +10,7 @@ PSPDFKit comes with open source plugins for Cordova on both [iOS](https://pspdfk
 - PSPDFKit 10.0.0 for iOS or later
 - Cordova Lib >= 10.0.0
 - Cordova iOS >= 5.1.1
-- CocoaPods >= 1.9.3
+- CocoaPods >= 1.10.0.rc.1
 
 ## Installation
 

--- a/docs/ios/README.md
+++ b/docs/ios/README.md
@@ -1,4 +1,4 @@
-# Cordova Plugin for PSPDFKit 9 for iOS
+# Cordova Plugin for PSPDFKit 10 for iOS
 
 The [PSPDFKit SDK](https://pspdfkit.com/pdf-sdk/) is a framework that allows you to view, annotate, sign, and fill PDF forms on iOS, Android, Windows, macOS, and Web.
 
@@ -6,9 +6,9 @@ PSPDFKit comes with open source plugins for Cordova on both [iOS](https://pspdfk
 
 ## Requirements
 
-- Xcode 11.5 or later
-- PSPDFKit 9.5.0 for iOS or later
-- Cordova Lib >= 9.0.0
+- Xcode 12 or later
+- PSPDFKit 10.0.0 for iOS or later
+- Cordova Lib >= 10.0.0
 - Cordova iOS >= 5.1.1
 - CocoaPods >= 1.9.3
 

--- a/plugin.xml
+++ b/plugin.xml
@@ -95,7 +95,7 @@ AND MAY NOT BE RESOLD OR REDISTRIBUTED. USAGE IS BOUND TO THE PSPDFKIT LICENSE A
         <source url="https://github.com/CocoaPods/Specs.git" />
       </config>
       <pods use-frameworks="true">
-        <pod name="PSPDFKit" options="podspec: 'https://customers.pspdfkit.com/pspdfkit-ios/latest.podspec'" />
+        <pod name="PSPDFKit" options="podspec: 'https://customers.pspdfkit.com/pspdfkit-ios/latest-framework.podspec'" />
       </pods>
     </podspec>
   </platform>

--- a/plugin.xml
+++ b/plugin.xml
@@ -95,7 +95,7 @@ AND MAY NOT BE RESOLD OR REDISTRIBUTED. USAGE IS BOUND TO THE PSPDFKIT LICENSE A
         <source url="https://github.com/CocoaPods/Specs.git" />
       </config>
       <pods use-frameworks="true">
-        <pod name="PSPDFKit" options="podspec: 'https://customers.pspdfkit.com/pspdfkit-ios/latest-framework.podspec'" />
+        <pod name="PSPDFKit" options="podspec: 'https://customers.pspdfkit.com/pspdfkit-ios/latest.podspec'" />
       </pods>
     </podspec>
   </platform>


### PR DESCRIPTION
⚠️ Only merge after PSPDFKit 10 for iOS is released ⚠️ 

---

# Details

This PR updates the plugin for PSPDFKit 10 for iOS, Xcode 12, and cordova-lib 10.0.0.

This PR also updates the podspec URL to use the fat frameworks instead of the XCFrameworks, because of the known CocoaPods issues with XCFrameworks (https://github.com/CocoaPods/CocoaPods/issues/9681 and https://github.com/CocoaPods/CocoaPods/issues/9990)

# Acceptance Criteria

- [x] When approved, right before merging, rebase with master and increment the package version in `package.json` and `plugin.xml`(see example commit: https://github.com/PSPDFKit/PSPDFKit-Cordova/commit/09d5c6b1c12977dc2248c02d869c3247ff5ed6f5).
- [ ] Create a new release (and tag) with the new package version (see https://github.com/PSPDFKit/PSPDFKit-Cordova/releases).
- [ ] Locally, pull the latest master and publish (`npm publish`) the new release to [npm](https://www.npmjs.com/package/pspdfkit-cordova).
