### PR TITLE
Bump Android version and Cordova version

### DIFF
--- a/docs/android/README.md
+++ b/docs/android/README.md
@@ -9,7 +9,7 @@ This plugin defines a global `PSPDFKit` object, which provides an API for viewin
 ## Requirements
 - Android SDK API level 19+ / Android 4.4+ (KitKat)
 - Cordova Android 8+.
-- PSPDFKit for Android 6.5
+- PSPDFKit for Android 6.5.2
 
 ## Installation
 

--- a/docs/android/README.md
+++ b/docs/android/README.md
@@ -157,9 +157,22 @@ cordova plugin add https://github.com/PSPDFKit/PSPDFKit-Cordova.git
 pspdfkit.license=LICENSE_STRING
 ```
 
+
 > Note: If you're already a customer then please make sure that the package ID matches with your bundle ID that's assigned to your license (e.g. com.ionic.test). You can check this in your `AndroidManifest.xml` by searching for `package`. If you are using a trial license then you don't have to worry about that.
 
-5. Now open your `index.js` file located in `www/js/` and paste the below code into the `receivedEvent: function(id)` function. For this to work you need to create a folder called `documents` in `www` and paste a PDF in this folder.
+5. PSPDFKit requires modern Jetpack libraries AndroidX. To enable AndroidX modify the `config.xml` adding the following line in the `android` section:
+
+```diff
+...
+<platform name="android">
++   <preference name="AndroidXEnabled" value="true" />
+    <allow-intent href="market:*" />
+</platform>
+...
+
+```
+
+6. Now open your `index.js` file located in `www/js/` and paste the below code into the `onDeviceReady()` function. For this to work you need to create a folder called `documents` in `www` and paste a PDF in this folder.
 
 ```javascript
 PSPDFKit.presentFromAssets("www/documents/A.pdf", {
@@ -171,7 +184,7 @@ PSPDFKit.presentFromAssets("www/documents/A.pdf", {
 });
 ```
 
-6. You are now ready to build and test your app!
+7. You are now ready to build and test your app!
 
 ```shell
 cordova build

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pspdfkit-cordova",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "PSPDFKit Cordova Plugin for Android and iOS",
   "cordova": {
     "id": "pspdfkit-cordova",

--- a/plugin.xml
+++ b/plugin.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<plugin xmlns="http://apache.org/cordova/ns/plugins/1.0" xmlns:android="http://schemas.android.com/apk/res/android" id="pspdfkit-cordova" version="1.1.0">
+<plugin xmlns="http://apache.org/cordova/ns/plugins/1.0" xmlns:android="http://schemas.android.com/apk/res/android" id="pspdfkit-cordova" version="1.1.1">
   <engines>
     <engine name="cordova" version="&gt;=6.3.1" />
   </engines>

--- a/src/android/config.gradle
+++ b/src/android/config.gradle
@@ -31,5 +31,5 @@ if (pspdfkitLicense == null || pspdfkitLicense == '') {
 ext.pspdfkitMavenModuleName = 'pspdfkit'
 ext.pspdfkitVersion = localProperties.getProperty('pspdfkit.version')
 if (pspdfkitVersion == null || pspdfkitVersion == '') {
-    ext.pspdfkitVersion = '6.5.0'
+    ext.pspdfkitVersion = '6.5.2'
 }


### PR DESCRIPTION
# Details

This PR updates the wrapper to PSPDFKit 6.5.2 for Android.
Also, it improves the README file .

# Acceptance Criteria

- [x] When approved, right before merging, rebase with master and increment the package version in `package.json` and `plugin.xml`(see example commit: https://github.com/PSPDFKit/PSPDFKit-Cordova/commit/09d5c6b1c12977dc2248c02d869c3247ff5ed6f5).
- [ ] Create a new release (and tag) with the new package version (see https://github.com/PSPDFKit/PSPDFKit-Cordova/releases).
- [ ] Locally, pull the latest master and publish (`npm publish`) the new release to [npm](https://www.npmjs.com/package/pspdfkit-cordova).
