### PR TITLE
Update to PSPDFKit 6.5.3 for Android

### DIFF
--- a/docs/android/README.md
+++ b/docs/android/README.md
@@ -9,7 +9,7 @@ This plugin defines a global `PSPDFKit` object, which provides an API for viewin
 ## Requirements
 - Android SDK API level 19+ / Android 4.4+ (KitKat)
 - Cordova Android 8+.
-- PSPDFKit for Android 6.5.2
+- PSPDFKit for Android 6.5.3
 
 ## Installation
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pspdfkit-cordova",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "description": "PSPDFKit Cordova Plugin for Android and iOS",
   "cordova": {
     "id": "pspdfkit-cordova",

--- a/plugin.xml
+++ b/plugin.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<plugin xmlns="http://apache.org/cordova/ns/plugins/1.0" xmlns:android="http://schemas.android.com/apk/res/android" id="pspdfkit-cordova" version="1.1.1">
+<plugin xmlns="http://apache.org/cordova/ns/plugins/1.0" xmlns:android="http://schemas.android.com/apk/res/android" id="pspdfkit-cordova" version="1.1.2">
   <engines>
     <engine name="cordova" version="&gt;=6.3.1" />
   </engines>

--- a/src/android/config.gradle
+++ b/src/android/config.gradle
@@ -31,5 +31,5 @@ if (pspdfkitLicense == null || pspdfkitLicense == '') {
 ext.pspdfkitMavenModuleName = 'pspdfkit'
 ext.pspdfkitVersion = localProperties.getProperty('pspdfkit.version')
 if (pspdfkitVersion == null || pspdfkitVersion == '') {
-    ext.pspdfkitVersion = '6.5.2'
+    ext.pspdfkitVersion = '6.5.3'
 }


### PR DESCRIPTION
# Details

This PR updates the wrapper for PSPDFKit 6.5.3 for Android.

# Acceptance Criteria

- [x] When approved, right before merging, rebase with master and increment the package version in `package.json` and `plugin.xml`(see example commit: https://github.com/PSPDFKit/PSPDFKit-Cordova/commit/09d5c6b1c12977dc2248c02d869c3247ff5ed6f5).
- [ ] Create a new release (and tag) with the new package version (see https://github.com/PSPDFKit/PSPDFKit-Cordova/releases).
- [ ] Locally, pull the latest master and publish (`npm publish`) the new release to [npm](https://www.npmjs.com/package/pspdfkit-cordova).
