### PR TITLE
Fix Android manifest editing conflict

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -49,13 +49,13 @@ AND MAY NOT BE RESOLD OR REDISTRIBUTED. USAGE IS BOUND TO THE PSPDFKIT LICENSE A
         <param name="android-package" value="com.pspdfkit.cordova.PSPDFKitPlugin" />
       </feature>
     </config-file>
-    <config-file parent="/*/application" target="AndroidManifest.xml">
+    <config-file target="app/src/main/AndroidManifest.xml" parent="/*/application">
       <meta-data android:name="pspdfkit_license_key" android:value="@string/PSPDFKIT_LICENSE_KEY" />
     </config-file>
-    <config-file parent="/*/application" target="AndroidManifest.xml" after="activity">
+    <config-file target="app/src/main/AndroidManifest.xml" parent="/*/application" after="activity">
       <activity android:name="com.pspdfkit.cordova.CordovaPdfActivity" android:theme="@style/PSPDFKit.Theme" android:windowSoftInputMode="adjustNothing" />
     </config-file>
-    <edit-config file="AndroidManifest.xml" target="/manifest/application" mode="merge">
+    <edit-config file="app/src/main/AndroidManifest.xml" target="/manifest/application" mode="merge">
       <application android:largeHeap="true" />
     </edit-config>
     


### PR DESCRIPTION
`<edit-config>` rule inside `plugin.xml` could produce conflicts with other plugins if they also modified Android manifest in their installation.

# Details

The issue is in the Cordova itself. Changing the target file of the `edit-config` rule to full manifest path instead of using the filename solved the issue. See [here]((https://github.com/apache/cordova-android/issues/801)
) for the same issue reported in `cordova-android` repo.

# Acceptance Criteria

- [ ] When approved, right before merging, rebase with master and increment the package version in `package.json` and `plugin.xml`(see example commit: https://github.com/PSPDFKit/PSPDFKit-Cordova/commit/09d5c6b1c12977dc2248c02d869c3247ff5ed6f5).
- [ ] Create a new release (and tag) with the new package version (see https://github.com/PSPDFKit/PSPDFKit-Cordova/releases).
- [ ] Locally, pull the latest master and publish (`npm publish`) the new release to [npm](https://www.npmjs.com/package/pspdfkit-cordova).
