### PR TITLE
Update to PSPDFKit 6.6.2 for Android

### DIFF
--- a/docs/android/README.md
+++ b/docs/android/README.md
@@ -525,7 +525,7 @@ You can find the API documentation in [PSPDFKit.js](../../www/PSPDFKit.js).
 
 ## Troubleshooting
 
-### PSPDFKit runs in trial mode
+### Setting the license key / PSPDFKit runs in trial mode
 
 If you're already a customer then please make sure that the package ID matches with your bundle ID that's assigned to your license (e.g. io.ionic.starter). You can check this in your `AndroidManifest.xml` by searching for `package`.
 
@@ -533,6 +533,7 @@ Make sure that you are setting the license key via `PSPDFKit.setLicenseKey()`.
 If you used the PSPDFKit Cordova plugin previously, you might still have `pspdfkit.license=YOUR LICENSE` set in `local.properties`. 
 This is no longer supported.
 Please make sure to migrate this to use `PSPDFKit.setLicenseKey("YOUR LICENSE")`.
+If you are a trial customer, you won't need to call `PSPDFKit.setLicenseKey()` at all.
 
 ### Error Reporting
 

--- a/docs/android/README.md
+++ b/docs/android/README.md
@@ -152,6 +152,9 @@ The plugin is accessed via the PSPDFKit singleton. Here is an example which show
 
 ```javascript
 function showMyDocument() {
+  // Set your license key here.
+  PSPDFKit.setLicenseKey("YOUR KEY");
+
   PSPDFKit.presentFromAssets("www/documents/myFile.pdf", {
     title: "My PDF Document",
     page: 4,
@@ -254,7 +257,7 @@ cordova create pdfapp com.example.pdfapp PDF-App
 cd pdfapp
 ```
 
-> Important: Your app's package name (in the above example `com.example.pdfapp`) has to match your PSPDFKit license name or PSPDFKit will throw an exception. If you don't have a license yet, you can request an evaluation license of PSPDFKit at https://pspdfkit.com/try.
+> Important: Your app's package name (in the above example `com.example.pdfapp`) has to match your PSPDFKit license name or PSPDFKit will throw an exception.
 
 3. Open `config.xml` in a text editor to enable AndroidX and to change the deployment target to iOS 12 or later:
 
@@ -291,21 +294,13 @@ cordova plugin add https://github.com/PSPDFKit/PSPDFKit-Cordova.git
 cordova platform add android
 ```
 
-4. Next, you need to setup your PSPDFKit license key. If you don't have a license key yet, you can get one by requesting an evaluation version of PSPDFKit at https://pspdfkit.com/try. Inside your Android app's `platforms/android/local.properties` file, specify the `pspdfkit.license` property:
-
-```shell
-echo "pspdfkit.license=LICENSE_KEY_GOES_HERE" >> platforms/android/local.properties
-```
-
-> Note: If you're already a customer then please make sure that the package ID matches with your bundle ID that's assigned to your license (e.g. com.example.pdfapp). You can check this in your `AndroidManifest.xml` by searching for `package`. If you are using a trial license then you don't have to worry about that.
-
-5. Add the PDF document you want to display in your project’s `assets` directory. You can use <a href="https://pspdfkit.com/downloads/pspdfkit-android-quickstart-guide.pdf" download="Document.pdf">this QuickStart Guide PDF</a> as an example.
+4. Add the PDF document you want to display in your project’s `assets` directory. You can use <a href="https://pspdfkit.com/downloads/pspdfkit-android-quickstart-guide.pdf" download="Document.pdf">this QuickStart Guide PDF</a> as an example.
 
 ```shell
 cp ~/Downloads/Document.pdf platforms/android/app/src/main/assets/Document.pdf
 ```
 
-6. Now open your `index.js` file located in `www/js/` and paste the below code into the `onDeviceReady()` function:
+5. Now open your `index.js` file located in `www/js/` and paste the below code into the `onDeviceReady()` function:
 
 ```javascript
 PSPDFKit.present("file:///android_asset/Document.pdf", {
@@ -317,8 +312,8 @@ PSPDFKit.present("file:///android_asset/Document.pdf", {
 });
 ```
 
-7. [Start your emulator](https://developer.android.com/studio/run/emulator#runningemulator).
-8. The app is now ready to launch:
+6. [Start your emulator](https://developer.android.com/studio/run/emulator#runningemulator).
+7. The app is now ready to launch:
 
 ```shell
 cordova emulate android
@@ -350,20 +345,14 @@ npm install
 cordova platform add android
 ```
 
-4. Add the trial license key to the `platforms/android/local.properties` file:
-
-```shell
-echo "pspdfkit.license=LICENSE_KEY_GOES_HERE" >> platforms/android/local.properties
-```
-
-5. Copy the PDF document from the `www` directory into your project’s assets directory:
+4. Copy the PDF document from the `www` directory into your project’s assets directory:
 
 ```shell
 cp www/Document.pdf platforms/android/app/src/main/assets/Document.pdf
 ```
 
-6. [Start your emulator](https://developer.android.com/studio/run/emulator#runningemulator).
-7. The app is now ready to launch:
+5. [Start your emulator](https://developer.android.com/studio/run/emulator#runningemulator).
+6. The app is now ready to launch:
 
 ```shell
 cordova emulate android
@@ -453,22 +442,14 @@ export class AppComponent {
 
 7. Run `ionic cordova platform add android` to add the Android platform.
 
-8. Next, you need to set up your PSPDFKit license key. If you don't have a license key yet, you can get one by requesting an evaluation version of PSPDFKit at https://pspdfkit.com/try. Specify the `pspdfkit.license` property inside your Android app's `platforms/android/local.properties` file, create the file if it does not exist:
-
-```shell
-echo "pspdfkit.license=LICENSE_KEY_GOES_HERE" >> platforms/android/local.properties
-```
-
-> Note: If you're already a customer then please make sure that the package ID matches with your bundle ID that's assigned to your license (e.g. io.ionic.starter). You can check this in your `AndroidManifest.xml` by searching for `package`. If you are using a trial license then you don't have to worry about that.
-
-9. Add the PDF document you want to display in your project’s `assets` directory. You can use <a href="https://pspdfkit.com/downloads/pspdfkit-android-quickstart-guide.pdf" download="Document.pdf">this QuickStart Guide PDF</a> as an example.
+8. Add the PDF document you want to display in your project’s `assets` directory. You can use <a href="https://pspdfkit.com/downloads/pspdfkit-android-quickstart-guide.pdf" download="Document.pdf">this QuickStart Guide PDF</a> as an example.
 
 ```shell
 cp ~/Downloads/Document.pdf platforms/android/app/src/main/assets/Document.pdf
 ```
 
-7. [Start your emulator](https://developer.android.com/studio/run/emulator#runningemulator).
-8. The app is now ready to launch:
+9. [Start your emulator](https://developer.android.com/studio/run/emulator#runningemulator).
+10. The app is now ready to launch:
 
 ```shell
 ionic cordova emulate android
@@ -500,20 +481,14 @@ npm install
 ionic cordova platform add android
 ```
 
-4. Add the trial license key to the `platforms/android/local.properties` file:
-
-```shell
-echo "pspdfkit.license=LICENSE_KEY_GOES_HERE" >> platforms/android/local.properties
-```
-
-5. Copy the PDF document from the `resources` directory into your project’s `assets` directory:
+4. Copy the PDF document from the `resources` directory into your project’s `assets` directory:
 
 ```shell
 cp resources/Document.pdf platforms/android/app/src/main/assets/Document.pdf
 ```
 
-6. [Start your emulator](https://developer.android.com/studio/run/emulator#runningemulator).
-7. The app is now ready to launch:
+5. [Start your emulator](https://developer.android.com/studio/run/emulator#runningemulator).
+6. The app is now ready to launch:
 
 ```shell
 ionic cordova emulate android
@@ -549,6 +524,15 @@ Below is a screenshot of how the project structure should look like if it's a wo
 You can find the API documentation in [PSPDFKit.js](../../www/PSPDFKit.js).
 
 ## Troubleshooting
+
+### PSPDFKit runs in trial mode
+
+If you're already a customer then please make sure that the package ID matches with your bundle ID that's assigned to your license (e.g. io.ionic.starter). You can check this in your `AndroidManifest.xml` by searching for `package`.
+
+Make sure that you are setting the license key via `PSPDFKit.setLicenseKey()`.
+If you used the PSPDFKit Cordova plugin previously, you might still have `pspdfkit.license=YOUR LICENSE` set in `local.properties`. 
+This is no longer supported.
+Please make sure to migrate this to use `PSPDFKit.setLicenseKey("YOUR LICENSE")`.
 
 ### Error Reporting
 
@@ -704,7 +688,7 @@ To solve this just uninstall the existing app from your device. To be 100% sure 
 
 ### Build succeeds but it doesn't show the document on the device
 
-Please make sure that your license key is properly set in the `AndroidManifest.xml`! You can also open a new terminal window and type `adb logcat` to see exactly what's happening on your device. When searching for "PSPDFKit" you should be able to search for the error rather easily.
+Please make sure that your license key is properly set via `PSPDFKit.setLicenseKey()`. You can also open a new terminal window and type `adb logcat` to see exactly what's happening on your device. When searching for "PSPDFKit" you should be able to search for the error rather easily.
 
 ### Can't find version for a specific support library
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pspdfkit-cordova",
-  "version": "1.1.9",
+  "version": "1.1.10",
   "description": "PSPDFKit Cordova Plugin for Android and iOS",
   "cordova": {
     "id": "pspdfkit-cordova",

--- a/plugin.xml
+++ b/plugin.xml
@@ -35,6 +35,7 @@ AND MAY NOT BE RESOLD OR REDISTRIBUTED. USAGE IS BOUND TO THE PSPDFKIT LICENSE A
     <source-file src="src/android/java/com/pspdfkit/cordova/action/ActionManager.java" target-dir="src/com/pspdfkit/cordova/action" />
     <source-file src="src/android/java/com/pspdfkit/cordova/action/BasicAction.java" target-dir="src/com/pspdfkit/cordova/action" />
     <source-file src="src/android/java/com/pspdfkit/cordova/action/DismissAction.java" target-dir="src/com/pspdfkit/cordova/action" />
+    <source-file src="src/android/java/com/pspdfkit/cordova/action/LicenseKeyAction.java" target-dir="src/com/pspdfkit/cordova/action" />
     <source-file src="src/android/java/com/pspdfkit/cordova/event/EventDispatcher.java" target-dir="src/com/pspdfkit/cordova/event" />
     <source-file src="src/android/java/com/pspdfkit/cordova/provider/DocumentJsonDataProvider.java" target-dir="src/com/pspdfkit/cordova/provider" />
     <source-file src="src/android/java/com/pspdfkit/cordova/CordovaPdfActivity.java" target-dir="src/com/pspdfkit/cordova" />
@@ -48,9 +49,6 @@ AND MAY NOT BE RESOLD OR REDISTRIBUTED. USAGE IS BOUND TO THE PSPDFKIT LICENSE A
       <feature name="PSPDFKitPlugin">
         <param name="android-package" value="com.pspdfkit.cordova.PSPDFKitPlugin" />
       </feature>
-    </config-file>
-    <config-file target="app/src/main/AndroidManifest.xml" parent="/*/application">
-      <meta-data android:name="pspdfkit_license_key" android:value="@string/PSPDFKIT_LICENSE_KEY" />
     </config-file>
     <config-file target="app/src/main/AndroidManifest.xml" parent="/*/application" after="activity">
       <activity android:name="com.pspdfkit.cordova.CordovaPdfActivity" android:theme="@style/PSPDFKit.Theme" android:windowSoftInputMode="adjustNothing" />

--- a/plugin.xml
+++ b/plugin.xml
@@ -103,24 +103,10 @@ AND MAY NOT BE RESOLD OR REDISTRIBUTED. USAGE IS BOUND TO THE PSPDFKIT LICENSE A
   <!-- don't indent the info block, because it will also indent the console output -->
   <info><![CDATA[Thanks for using the PSPDFKit for Cordova/Ionic Plugin. 
 
-### iOS
+**Important** If you’re an existing customer, you can find your license key in your customer portal(https://customers.pspdfkit.com/).
 
-**Important** If you’re an existing customer, you can find your license key in your customer portal(https://customers.pspdfkit.com/). Otherwise, if you don’t already have PSPDFKit, sign up for our 60-day trial(https://pspdfkit.com/try/) and you will receive an email with the instructions to get started.
-
-Since this plugin is iOS 12+ only, you will have to set the deployment target
+iOS: Since this plugin is iOS 12+ only, you will have to set the deployment target
 of your Xcode project in platforms/ios to iOS 12.
-
-### Android
-
-There's only on more step to get you started:
-
-    1) You need to add following lines to the `local.properties` (usually inside platforms/android/): 
-
-    pspdfkit.license = YOUR_PSPDFKIT_LICENSE
-
-    Make sure to replace YOUR_PSPDFKIT_LICENSE with the actual PSPDFKit license string that you
-    received while requesting a demo at https://pspdfkit.com/try/ or via the 
-    PSPDFKit customer portal (in case you already own a license).
 
 For the complete documentation and troubleshooting, check out our documentation at https://github.com/PSPDFKit/PSPDFKit-Cordova. 
 In case there are issues, feel free to reach out to our support team at https://pspdfkit.com/support/request/.

--- a/plugin.xml
+++ b/plugin.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<plugin xmlns="http://apache.org/cordova/ns/plugins/1.0" xmlns:android="http://schemas.android.com/apk/res/android" id="pspdfkit-cordova" version="1.1.9">
+<plugin xmlns="http://apache.org/cordova/ns/plugins/1.0" xmlns:android="http://schemas.android.com/apk/res/android" id="pspdfkit-cordova" version="1.1.10">
   <engines>
     <engine name="cordova" version="&gt;=6.3.1" />
   </engines>

--- a/src/android/config.gradle
+++ b/src/android/config.gradle
@@ -25,5 +25,5 @@ ext.pspdfkitLicense = localProperties.getProperty('pspdfkit.license')
 ext.pspdfkitMavenModuleName = 'pspdfkit'
 ext.pspdfkitVersion = localProperties.getProperty('pspdfkit.version')
 if (pspdfkitVersion == null || pspdfkitVersion == '') {
-    ext.pspdfkitVersion = '6.5.3'
+    ext.pspdfkitVersion = '6.6.2'
 }

--- a/src/android/config.gradle
+++ b/src/android/config.gradle
@@ -20,8 +20,6 @@ if (pspdfkitMavenUrl == null || pspdfkitMavenUrl == '') {
     ext.pspdfkitMavenUrl = 'https://customers.pspdfkit.com/maven/'
 }
 
-ext.pspdfkitLicense = localProperties.getProperty('pspdfkit.license')
-
 ext.pspdfkitMavenModuleName = 'pspdfkit'
 ext.pspdfkitVersion = localProperties.getProperty('pspdfkit.version')
 if (pspdfkitVersion == null || pspdfkitVersion == '') {

--- a/src/android/config.gradle
+++ b/src/android/config.gradle
@@ -21,12 +21,6 @@ if (pspdfkitMavenUrl == null || pspdfkitMavenUrl == '') {
 }
 
 ext.pspdfkitLicense = localProperties.getProperty('pspdfkit.license')
-if (pspdfkitLicense == null || pspdfkitLicense == '') {
-    throw new GradleException("PSPDFKit license was not specified. The license is required to initialize and run PSPDFKit."
-        + " Please specify as pspdfkit.license inside the local.properties file. In case you don't own a license for PSPDFKit"
-        + " yet, you can request an evaluation copy of PSPDFKit at https://pspdfkit.com/try/. If you already own a license of"
-        + " PSPDFKit, you can access it at https://customers.pspdfkit.com/.")
-}
 
 ext.pspdfkitMavenModuleName = 'pspdfkit'
 ext.pspdfkitVersion = localProperties.getProperty('pspdfkit.version')

--- a/src/android/java/com/pspdfkit/cordova/PSPDFKitPlugin.java
+++ b/src/android/java/com/pspdfkit/cordova/PSPDFKitPlugin.java
@@ -16,6 +16,7 @@ import android.text.TextUtils;
 import com.pspdfkit.PSPDFKit;
 import com.pspdfkit.cordova.action.ActionManager;
 import com.pspdfkit.cordova.action.DismissAction;
+import com.pspdfkit.cordova.action.LicenseKeyAction;
 import com.pspdfkit.cordova.action.annotation.AddAnnotationAction;
 import com.pspdfkit.cordova.action.annotation.ApplyInstantJsonAction;
 import com.pspdfkit.cordova.action.annotation.GetAllUnsavedAnnotationsAction;
@@ -51,10 +52,6 @@ import androidx.annotation.NonNull;
  * JavaScript using the {@code PSPDFKit} object.
  */
 public class PSPDFKitPlugin extends CordovaPlugin {
-  /**
-   * Name of a {@code meta-data} element in the app manifest file holding the PSPDFKit license key.
-   */
-  private static final String METADATA_LICENSE_KEY = "pspdfkit_license_key";
 
   @NonNull
   private final List<OnActivityResultListener> onActivityResultListeners = new ArrayList<>();
@@ -65,8 +62,6 @@ public class PSPDFKitPlugin extends CordovaPlugin {
   @Override
   public void initialize(CordovaInterface cordova, CordovaWebView webView) {
     super.initialize(cordova, webView);
-
-    initializePSPDFKit(cordova);
 
     final EventDispatcher.EventDispatchingActions connectionActions =
         eventDispatcher.getConnectionActions(this);
@@ -91,33 +86,14 @@ public class PSPDFKitPlugin extends CordovaPlugin {
             new ClearCacheAction("clearCache", this),
             new ClearCacheForPageAction("clearCacheForPage", this),
             new RemoveCacheForPresentedDocumentAction("removeCacheForPresentedDocument", this),
-            new GetHasDirtyAnnotationsAction("getHasDirtyAnnotations", this)
+            new GetHasDirtyAnnotationsAction("getHasDirtyAnnotations", this),
+            new LicenseKeyAction("setLicenseKey", this)
         );
   }
 
-  private void initializePSPDFKit(CordovaInterface cordova) {
-    final String licenseKey;
+  public void setLicenseKey(String licenseKey) {
     try {
-      licenseKey =
-          cordova
-              .getActivity()
-              .getPackageManager()
-              .getApplicationInfo(
-                  cordova.getActivity().getPackageName(), PackageManager.GET_META_DATA)
-              .metaData
-              .getString(METADATA_LICENSE_KEY, null);
-    } catch (PackageManager.NameNotFoundException e) {
-      throw new PSPDFKitPluginException(
-          "Error while reading PSPDFKit license from AndroidManifest.xml", e);
-    }
-
-    if (TextUtils.isEmpty(licenseKey)) {
-      throw new PSPDFKitPluginException(
-          "PSPDFKit license key is missing! Please add a <meta-data android:name=\"pspdfkit_license_key\" android:value=\"...\"> to your AndroidManifest.xml.");
-    }
-
-    try {
-      PSPDFKit.initialize(cordova.getActivity(), licenseKey);
+      PSPDFKit.initialize(this.cordova.getActivity(), licenseKey);
     } catch (Exception ex) {
       throw new PSPDFKitPluginException("Error while initializing PSPDFKit", ex);
     }

--- a/src/android/java/com/pspdfkit/cordova/action/LicenseKeyAction.java
+++ b/src/android/java/com/pspdfkit/cordova/action/LicenseKeyAction.java
@@ -1,0 +1,33 @@
+package com.pspdfkit.cordova.action;
+
+import android.content.Intent;
+
+import com.pspdfkit.PSPDFKit;
+import com.pspdfkit.cordova.CordovaPdfActivity;
+import com.pspdfkit.cordova.PSPDFKitPlugin;
+
+import org.apache.cordova.CallbackContext;
+import org.json.JSONArray;
+import org.json.JSONException;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+
+/**
+ * Action to set a license key.
+ */
+public class LicenseKeyAction extends BasicAction {
+
+  private static final int ARG_LICENSE_KEY = 0;
+
+  public LicenseKeyAction(@NonNull String name, @NonNull PSPDFKitPlugin plugin) {
+    super(name, plugin);
+  }
+
+  @Override
+  protected void execAction(JSONArray args, CallbackContext callbackContext) throws JSONException {
+    final String licenseKey = args.getString(ARG_LICENSE_KEY);
+    this.getPlugin().setLicenseKey(licenseKey);
+    callbackContext.success();
+  }
+}

--- a/src/android/pspdfkit.gradle
+++ b/src/android/pspdfkit.gradle
@@ -16,13 +16,6 @@ repositories {
     }
 }
 
-android {
-    defaultConfig {
-        // The license string has to be specified in your app's local.properties file, for example:
-        // pspdfkit.license = MY_LICENSE_STRING.
-        resValue "string", "PSPDFKIT_LICENSE_KEY", "\"$pspdfkitLicense\""
-    }
-}
 dependencies {
     implementation "com.pspdfkit:$pspdfkitMavenModuleName:$pspdfkitVersion"
 }

--- a/www/PSPDFKit.js
+++ b/www/PSPDFKit.js
@@ -24,13 +24,10 @@ var platform = window.cordova.platformId;
  * __Supported Platforms__
  *
  * -iOS
+ * -Android
  */
 exports.setLicenseKey = function(key, callback) {
-  if (platform === "ios") {
     executeAction(callback, "setLicenseKey", [key]);
-  } else {
-    console.log("Not implemented on " + platform + ".");
-  }
 };
 
 /**


### PR DESCRIPTION
# Details

This updates to PSPDFKit 6.6.2 for Android.
And changes the way a license key is set.

License keys are no longer set via `pspdfkit.license` in `local.properties`, but are now using the `PSPDFKit.setLicenseKey("YOUR KEY")` API, which matches iOS.

# Acceptance Criteria

- [x] When approved, right before merging, rebase with master and increment the package version in `package.json` and `plugin.xml`(see example commit: https://github.com/PSPDFKit/PSPDFKit-Cordova/commit/09d5c6b1c12977dc2248c02d869c3247ff5ed6f5).
- [ ] Create a new release (and tag) with the new package version (see https://github.com/PSPDFKit/PSPDFKit-Cordova/releases).
- [ ] Locally, pull the latest master and publish (`npm publish`) the new release to [npm](https://www.npmjs.com/package/pspdfkit-cordova).
