### PR TITLE
Update for PSPDFKit 10.5 for iOS

### DIFF
--- a/docs/android/README.md
+++ b/docs/android/README.md
@@ -47,7 +47,7 @@ cordova platform remove android
 cordova platform remove ios
 ```
 
-3. Open `config.xml` in a text editor to enable AndroidX and to change the deployment target to iOS 12 or later:
+3. Open `config.xml` in a text editor to enable AndroidX and to change the deployment target to iOS 13 or later:
 
 ```bash
 open config.xml
@@ -64,7 +64,7 @@ Your `config.xml` file should look like this:
   <platform name="ios">
     <allow-intent href="itms:*" />
     <allow-intent href="itms-apps:*" />
-+   <preference name="deployment-target" value="12.0" />
++   <preference name="deployment-target" value="13.0" />
     ...
   </platform>
 ...
@@ -100,7 +100,7 @@ ionic cordova platform remove android
 ionic cordova platform remove ios
 ```
 
-3. Open `config.xml` in a text editor to enable AndroidX and to change the deployment target to iOS 12 or later:
+3. Open `config.xml` in a text editor to enable AndroidX and to change the deployment target to iOS 13 or later:
 
 ```bash
 open config.xml
@@ -121,7 +121,7 @@ Your `config.xml` file should look like this:
     <allow-intent href="itms:*" />
     <allow-intent href="itms-apps:*" />
 +   <allow-navigation href="*" />
-+   <preference name="deployment-target" value="12.0" />
++   <preference name="deployment-target" value="13.0" />
     ...
   </platform>
 ...
@@ -259,7 +259,7 @@ cd pdfapp
 
 > Important: Your app's package name (in the above example `com.example.pdfapp`) has to match your PSPDFKit license name or PSPDFKit will throw an exception.
 
-3. Open `config.xml` in a text editor to enable AndroidX and to change the deployment target to iOS 12 or later:
+3. Open `config.xml` in a text editor to enable AndroidX and to change the deployment target to iOS 13 or later:
 
 ```bash
 open config.xml
@@ -276,7 +276,7 @@ Your `config.xml` file should look like this:
   <platform name="ios">
     <allow-intent href="itms:*" />
     <allow-intent href="itms-apps:*" />
-+   <preference name="deployment-target" value="12.0" />
++   <preference name="deployment-target" value="13.0" />
     ...
   </platform>
 ...
@@ -377,7 +377,7 @@ cd PSPDFKit-Demo
 ionic cordova plugin add https://github.com/PSPDFKit/PSPDFKit-Cordova.git
 ```
 
-3. Open `config.xml` in a text editor to enable AndroidX and to change the deployment target to iOS 12 or later:
+3. Open `config.xml` in a text editor to enable AndroidX and to change the deployment target to iOS 13 or later:
 
 ```bash
 open config.xml
@@ -398,7 +398,7 @@ Your `config.xml` file should look like this:
     <allow-intent href="itms:*" />
     <allow-intent href="itms-apps:*" />
 +   <allow-navigation href="*" />
-+   <preference name="deployment-target" value="12.0" />
++   <preference name="deployment-target" value="13.0" />
     ...
   </platform>
 ...

--- a/docs/ios/README.md
+++ b/docs/ios/README.md
@@ -1,4 +1,4 @@
-# Cordova Plugin for PSPDFKit 10 for iOS
+# Cordova Plugin for PSPDFKit for iOS
 
 The [PSPDFKit SDK](https://pspdfkit.com/pdf-sdk/) is a framework that allows you to view, annotate, sign, and fill PDF forms on iOS, Android, Windows, macOS, and Web.
 
@@ -38,7 +38,7 @@ cordova platform remove android
 cordova platform remove ios
 ```
 
-3. Open `config.xml` in a text editor to enable AndroidX and to change the deployment target to iOS 12 or later:
+3. Open `config.xml` in a text editor to enable AndroidX and to change the deployment target to iOS 13 or later:
 
 ```bash
 open config.xml
@@ -55,7 +55,7 @@ Your `config.xml` file should look like this:
   <platform name="ios">
     <allow-intent href="itms:*" />
     <allow-intent href="itms-apps:*" />
-+   <preference name="deployment-target" value="12.0" />
++   <preference name="deployment-target" value="13.0" />
     ...
   </platform>
 ...
@@ -91,7 +91,7 @@ ionic cordova platform remove android
 ionic cordova platform remove ios
 ```
 
-3. Open `config.xml` in a text editor to enable AndroidX and to change the deployment target to iOS 12 or later:
+3. Open `config.xml` in a text editor to enable AndroidX and to change the deployment target to iOS 13 or later:
 
 ```bash
 open config.xml
@@ -112,7 +112,7 @@ Your `config.xml` file should look like this:
     <allow-intent href="itms:*" />
     <allow-intent href="itms-apps:*" />
 +   <allow-navigation href="*" />
-+   <preference name="deployment-target" value="12.0" />
++   <preference name="deployment-target" value="13.0" />
     ...
   </platform>
 ...
@@ -184,7 +184,7 @@ cordova create PSPDFKit-Demo com.pspdfkit.demo PSPDFKit-Demo
 cd PSPDFKit-Demo
 ```
 
-2. Open `config.xml` and change the deployment target to iOS 12 or later:
+2. Open `config.xml` and change the deployment target to iOS 13 or later:
 
 ```diff
 ...
@@ -195,7 +195,7 @@ cd PSPDFKit-Demo
   <platform name="ios">
     <allow-intent href="itms:*" />
     <allow-intent href="itms-apps:*" />
-+   <preference name="deployment-target" value="12.0" />
++   <preference name="deployment-target" value="13.0" />
     ...
   </platform>
 ...
@@ -292,7 +292,7 @@ cd PSPDFKit-Demo
 ionic cordova plugin add https://github.com/PSPDFKit/PSPDFKit-Cordova.git
 ```
 
-3. Open `config.xml` in a text editor to enable AndroidX and to change the deployment target to iOS 12 or later:
+3. Open `config.xml` in a text editor to enable AndroidX and to change the deployment target to iOS 13 or later:
 
 ```bash
 open config.xml
@@ -313,7 +313,7 @@ Your `config.xml` file should look like this:
     <allow-intent href="itms:*" />
     <allow-intent href="itms-apps:*" />
 +   <allow-navigation href="*" />
-+   <preference name="deployment-target" value="12.0" />
++   <preference name="deployment-target" value="13.0" />
     ...
   </platform>
 ...
@@ -460,7 +460,7 @@ open platforms/ios/Podifile
 ```diff
 source 'https://github.com/CocoaPods/Specs.git'
 - platform :ios, '11.0'
-+ platform :ios, '12.0'
++ platform :ios, '13.0'
 use_frameworks!
 target 'MyApp' do
 	project 'MyApp.xcodeproj'

--- a/examples/cordova/PSPDFKit-Demo/config.xml
+++ b/examples/cordova/PSPDFKit-Demo/config.xml
@@ -23,6 +23,6 @@
     <platform name="ios">
         <allow-intent href="itms:*" />
         <allow-intent href="itms-apps:*" />
-        <preference name="deployment-target" value="12.0" />
+        <preference name="deployment-target" value="13.0" />
     </platform>
 </widget>

--- a/examples/ionic/PSPDFKit-Demo/config.xml
+++ b/examples/ionic/PSPDFKit-Demo/config.xml
@@ -45,7 +45,7 @@
         <allow-intent href="itms:*" />
         <allow-intent href="itms-apps:*" />
         <allow-navigation href="*" />
-        <preference name="deployment-target" value="12.0" />
+        <preference name="deployment-target" value="13.0" />
         <icon height="57" src="resources/ios/icon/icon.png" width="57" />
         <icon height="114" src="resources/ios/icon/icon@2x.png" width="114" />
         <icon height="29" src="resources/ios/icon/icon-small.png" width="29" />

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pspdfkit-cordova",
-  "version": "1.1.10",
+  "version": "1.1.11",
   "description": "PSPDFKit Cordova Plugin for Android and iOS",
   "cordova": {
     "id": "pspdfkit-cordova",

--- a/plugin.xml
+++ b/plugin.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<plugin xmlns="http://apache.org/cordova/ns/plugins/1.0" xmlns:android="http://schemas.android.com/apk/res/android" id="pspdfkit-cordova" version="1.1.10">
+<plugin xmlns="http://apache.org/cordova/ns/plugins/1.0" xmlns:android="http://schemas.android.com/apk/res/android" id="pspdfkit-cordova" version="1.1.11">
   <engines>
     <engine name="cordova" version="&gt;=6.3.1" />
   </engines>

--- a/plugin.xml
+++ b/plugin.xml
@@ -105,8 +105,8 @@ AND MAY NOT BE RESOLD OR REDISTRIBUTED. USAGE IS BOUND TO THE PSPDFKIT LICENSE A
 
 **Important** If you’re an existing customer, you can find your license key in your customer portal(https://customers.pspdfkit.com/).
 
-iOS: Since this plugin is iOS 12+ only, you will have to set the deployment target
-of your Xcode project in platforms/ios to iOS 12.
+iOS: Since this plugin is iOS 13+ only, you will have to set the deployment target
+of your Xcode project in platforms/ios to iOS 13.
 
 For the complete documentation and troubleshooting, check out our documentation at https://github.com/PSPDFKit/PSPDFKit-Cordova. 
 In case there are issues, feel free to reach out to our support team at https://pspdfkit.com/support/request/.


### PR DESCRIPTION
# Details

This updates to PSPDFKit 10.5 for iOS.
And bumps the deployment target to iOS 13.

# Acceptance Criteria

- [x] When approved, right before merging, rebase with master and increment the package version in `package.json` and `plugin.xml`(see example commit: https://github.com/PSPDFKit/PSPDFKit-Cordova/commit/09d5c6b1c12977dc2248c02d869c3247ff5ed6f5).
- [ ] Create a new release (and tag) with the new package version (see https://github.com/PSPDFKit/PSPDFKit-Cordova/releases).
- [ ] Locally, pull the latest master and publish (`npm publish`) the new release to [npm](https://www.npmjs.com/package/pspdfkit-cordova).
