### PR TITLE
Remove deprecated API for `pageGrabberEnabled`

### DIFF
--- a/examples/cordova/PSPDFKit-Demo/package-lock.json
+++ b/examples/cordova/PSPDFKit-Demo/package-lock.json
@@ -39,8 +39,8 @@
       }
     },
     "node_modules/pspdfkit-cordova": {
-      "version": "1.1.11",
-      "resolved": "git+ssh://git@github.com/PSPDFKit/PSPDFKit-Cordova.git#a50a471f730492f4cea5f71cb1e0f73030413afe",
+      "version": "1.2.0",
+      "resolved": "git+ssh://git@github.com/PSPDFKit/PSPDFKit-Cordova.git#1666c2185149cbd4f5ec72050b88106b94c8f6a3",
       "license": "MIT"
     }
   },
@@ -57,7 +57,7 @@
       "dev": true
     },
     "pspdfkit-cordova": {
-      "version": "git+ssh://git@github.com/PSPDFKit/PSPDFKit-Cordova.git#a50a471f730492f4cea5f71cb1e0f73030413afe",
+      "version": "git+ssh://git@github.com/PSPDFKit/PSPDFKit-Cordova.git#1666c2185149cbd4f5ec72050b88106b94c8f6a3",
       "from": "pspdfkit-cordova@git+https://github.com/PSPDFKit/PSPDFKit-Cordova.git"
     }
   }

--- a/examples/ionic/PSPDFKit-Demo/package-lock.json
+++ b/examples/ionic/PSPDFKit-Demo/package-lock.json
@@ -14837,8 +14837,8 @@
       "dev": true
     },
     "node_modules/pspdfkit-cordova": {
-      "version": "1.1.11",
-      "resolved": "git+ssh://git@github.com/PSPDFKit/PSPDFKit-Cordova.git#a50a471f730492f4cea5f71cb1e0f73030413afe",
+      "version": "1.2.0",
+      "resolved": "git+ssh://git@github.com/PSPDFKit/PSPDFKit-Cordova.git#1666c2185149cbd4f5ec72050b88106b94c8f6a3",
       "dev": true,
       "license": "MIT"
     },
@@ -30678,7 +30678,7 @@
       "dev": true
     },
     "pspdfkit-cordova": {
-      "version": "git+ssh://git@github.com/PSPDFKit/PSPDFKit-Cordova.git#a50a471f730492f4cea5f71cb1e0f73030413afe",
+      "version": "git+ssh://git@github.com/PSPDFKit/PSPDFKit-Cordova.git#1666c2185149cbd4f5ec72050b88106b94c8f6a3",
       "dev": true,
       "from": "pspdfkit-cordova@github:PSPDFKit/PSPDFKit-Cordova"
     },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pspdfkit-cordova",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "PSPDFKit Cordova Plugin for Android and iOS",
   "cordova": {
     "id": "pspdfkit-cordova",

--- a/plugin.xml
+++ b/plugin.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<plugin xmlns="http://apache.org/cordova/ns/plugins/1.0" xmlns:android="http://schemas.android.com/apk/res/android" id="pspdfkit-cordova" version="1.2.0">
+<plugin xmlns="http://apache.org/cordova/ns/plugins/1.0" xmlns:android="http://schemas.android.com/apk/res/android" id="pspdfkit-cordova" version="1.2.1">
   <engines>
     <engine name="cordova" version="&gt;=6.3.1" />
   </engines>

--- a/src/ios/PSPDFKitPlugin.m
+++ b/src/ios/PSPDFKitPlugin.m
@@ -1131,16 +1131,6 @@ void runOnMainQueueWithoutDeadlocking(void (^block)(void)) {
     return @(_pdfController.configuration.shouldAskForAnnotationUsername);
 }
 
-- (void)setPageGrabberEnabledForPSPDFViewControllerWithJSON:(NSNumber *)pageGrabberEnabled {
-    [_pdfController updateConfigurationWithBuilder:^(PSPDFConfigurationBuilder *builder) {
-        builder.pageGrabberEnabled = pageGrabberEnabled.boolValue;
-    }];
-}
-
-- (NSNumber *)pageGrabberEnabledAsJSON {
-    return @(_pdfController.configuration.pageGrabberEnabled);
-}
-
 - (void)setPageLabelEnabledForPSPDFViewControllerWithJSON:(NSNumber *)pageLabelEnabled {
     [_pdfController updateConfigurationWithBuilder:^(PSPDFConfigurationBuilder *builder) {
         builder.pageLabelEnabled = pageLabelEnabled.boolValue;


### PR DESCRIPTION
# Details

This PR is a followup for https://github.com/PSPDFKit/PSPDFKit-Cordova/pull/46, where we remove the now deprecated (since PSPDFKit 10.5 for iOS) `pageGrabberEnabled` configuration option.

## Release Notes:

- Remove deprecated API for `pageGrabberEnabled` (#49)

# Acceptance Criteria

- [x] When approved, right before merging, rebase with master and increment the package version in `package.json` and `plugin.xml`(see example commit: https://github.com/PSPDFKit/PSPDFKit-Cordova/commit/09d5c6b1c12977dc2248c02d869c3247ff5ed6f5).
- [ ] Create a new release (and tag) with the new package version (see https://github.com/PSPDFKit/PSPDFKit-Cordova/releases).
- [ ] Locally, pull the latest master and publish (`npm publish`) the new release to [npm](https://www.npmjs.com/package/pspdfkit-cordova).
