### PR TITLE
Release 1.5.3 and update plugin to support iOS 15+

### DIFF
--- a/docs/ios/README.md
+++ b/docs/ios/README.md
@@ -129,7 +129,7 @@ open platforms/ios/Podifile
 ```diff
 source 'https://github.com/CocoaPods/Specs.git'
 - platform :ios, '11.0'
-+ platform :ios, '14.0'
++ platform :ios, '15.0'
 use_frameworks!
 target 'MyApp' do
 	project 'MyApp.xcodeproj'

--- a/examples/cordova/PSPDFKit-Demo/config.xml
+++ b/examples/cordova/PSPDFKit-Demo/config.xml
@@ -29,6 +29,6 @@
     <platform name="ios">
         <allow-intent href="itms:*" />
         <allow-intent href="itms-apps:*" />
-        <preference name="deployment-target" value="14.0" />
+        <preference name="deployment-target" value="15.0" />
     </platform>
 </widget>

--- a/examples/ionic/PSPDFKit-Demo/config.xml
+++ b/examples/ionic/PSPDFKit-Demo/config.xml
@@ -47,7 +47,7 @@
         <allow-intent href="itms:*" />
         <allow-intent href="itms-apps:*" />
         <allow-navigation href="*" />
-        <preference name="deployment-target" value="14.0" />
+        <preference name="deployment-target" value="15.0" />
         <icon height="57" src="resources/ios/icon/icon.png" width="57" />
         <icon height="114" src="resources/ios/icon/icon@2x.png" width="114" />
         <icon height="29" src="resources/ios/icon/icon-small.png" width="29" />

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pspdfkit-cordova",
-  "version": "1.5.2",
+  "version": "1.5.3",
   "description": "PSPDFKit Cordova Plugin for Android and iOS",
   "cordova": {
     "id": "pspdfkit-cordova",

--- a/plugin.xml
+++ b/plugin.xml
@@ -104,8 +104,8 @@ AND MAY NOT BE RESOLD OR REDISTRIBUTED. USAGE IS BOUND TO THE PSPDFKIT LICENSE A
 
 **Important** If you’re an existing customer, you can find your license key in your customer portal(https://customers.pspdfkit.com/).
 
-iOS: Since this plugin is iOS 14+ only, you will have to set the deployment target
-of your Xcode project in platforms/ios to iOS 14.
+iOS: Since this plugin is iOS 15+ only, you will have to set the deployment target
+of your Xcode project in platforms/ios to iOS 15.
 
 For the complete documentation and troubleshooting, check out our documentation at https://github.com/PSPDFKit/PSPDFKit-Cordova. 
 In case there are issues, feel free to reach out to our support team at https://pspdfkit.com/support/request/.

--- a/plugin.xml
+++ b/plugin.xml
@@ -95,7 +95,7 @@ AND MAY NOT BE RESOLD OR REDISTRIBUTED. USAGE IS BOUND TO THE PSPDFKIT LICENSE A
         <source url="https://github.com/CocoaPods/Specs.git" />
       </config>
       <pods use-frameworks="true">
-        <pod name="PSPDFKit" spec="~> 11.4.0"/>
+        <pod name="PSPDFKit" spec="~> 12.4.0"/>
       </pods>
     </podspec>
   </platform>

--- a/plugin.xml
+++ b/plugin.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<plugin xmlns="http://apache.org/cordova/ns/plugins/1.0" xmlns:android="http://schemas.android.com/apk/res/android" id="pspdfkit-cordova" version="1.5.2">
+<plugin xmlns="http://apache.org/cordova/ns/plugins/1.0" xmlns:android="http://schemas.android.com/apk/res/android" id="pspdfkit-cordova" version="1.5.3">
   <engines>
     <engine name="cordova" version=">=10.1.0" />
     <engine name="cordova-android" version=">=10.1.1" />


### PR DESCRIPTION
# Details

This PR bumps the deployment target to iOS 15+, to support PSPDFKit 12.4 for iOS.

# Acceptance Criteria

- [x] When approved, right before merging, rebase with master and increment the package version in `package.json` and `plugin.xml`(see example commit: https://github.com/PSPDFKit/PSPDFKit-Cordova/commit/09d5c6b1c12977dc2248c02d869c3247ff5ed6f5).
- [ ] Create a new release (and tag) with the new package version (see https://github.com/PSPDFKit/PSPDFKit-Cordova/releases).
- [ ] Locally, pull the latest master and publish (`npm publish`) the new release to [npm](https://www.npmjs.com/package/pspdfkit-cordova).
